### PR TITLE
Update url more correctly.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/InfoFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/InfoFragment.java
@@ -122,6 +122,11 @@ public class InfoFragment extends WebFragment {
 
             @Override
             public void updateFailingUrl(String url, boolean updateFromError) {}
+
+            @Override
+            public void onReceivedTitle(WebView view, String title) {
+
+            }
         };
     }
 

--- a/app/src/main/java/org/mozilla/focus/web/IWebView.java
+++ b/app/src/main/java/org/mozilla/focus/web/IWebView.java
@@ -83,6 +83,8 @@ public interface IWebView {
                                    WebChromeClient.FileChooserParams fileChooserParams);
 
         void updateFailingUrl(String url, boolean updateFromError);
+
+        void onReceivedTitle(WebView view, String title);
     }
 
     interface FullscreenCallback {

--- a/app/src/webkit/java/org/mozilla/focus/webkit/WebkitView.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/WebkitView.java
@@ -262,6 +262,14 @@ public class WebkitView extends NestedWebView implements IWebView, SharedPrefere
 
             return callback.onShowFileChooser(webView, filePathCallback, fileChooserParams);
         }
+
+        @Override
+        public void onReceivedTitle(WebView view, String title) {
+            super.onReceivedTitle(view, title);
+            if (callback != null){
+                callback.onReceivedTitle(view,title);
+            }
+        }
     }
 
     public void insertBrowsingHistory() {
@@ -362,6 +370,11 @@ public class WebkitView extends NestedWebView implements IWebView, SharedPrefere
         @Override
         public void updateFailingUrl(String url, boolean updateFromError) {
             this.callback.updateFailingUrl(url, updateFromError);
+        }
+
+        @Override
+        public void onReceivedTitle(WebView view, String title) {
+            this.callback.onReceivedTitle(view,title);
         }
     }
 


### PR DESCRIPTION
Once in a while, url may not update correctly in onPageFinshed, for example, watching Youtube for a while and no matter capture screenshot or not.

STR:
1.Using for a while.
2.click any link.
3.The update url is old one, but the present of webView is right.
 
 So double check and update from onReceivedTitle is more correct but late for a bit.