### PR TITLE
bug: use newer API for Activity.onCreateView

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -670,13 +670,13 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
     }
 
     @Override
-    public View onCreateView(String name, Context context, AttributeSet attrs) {
+    public View onCreateView(View parent, String name, Context context, AttributeSet attrs) {
         if (name.equals(IWebView.class.getName())) {
             View v = WebViewProvider.create(this, attrs);
             return v;
         }
 
-        return super.onCreateView(name, context, attrs);
+        return super.onCreateView(parent, name, context, attrs);
     }
 
     @Override


### PR DESCRIPTION
in #1094 we got inflate exception. As reference from Fennec[1], to use
newer API might ease this problem. Let's give a try.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1377819