### PR TITLE
export MainActivity for recent-app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:screenOrientation="portrait"
             android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout"
             android:launchMode="singleTask"
-            android:exported="false" />
+            android:exported="true" />
 
         <activity-alias
             android:name="org.mozilla.rocket.activity.MainActivity"


### PR DESCRIPTION
If we try to re-launch Rocket via Recent-app, system tries to send
intent to **org.mozilla.focus.activity.MainActivity**, rather than our
activity-alias: **org.mozilla.rocket.activity.MainActivity**

To export the activity, then recen-app could deliver intent
successfully.

to fix #1136