### PR TITLE
web: allow Blob scheme to be loaded in TurboMode

### DIFF
--- a/app/src/webkit/java/org/mozilla/focus/webkit/TrackingProtectionWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/TrackingProtectionWebViewClient.java
@@ -77,8 +77,10 @@ public class TrackingProtectionWebViewClient extends WebViewClient {
         // via notifyCurrentURL in that case.
         final String scheme = resourceUri.getScheme();
 
-        if (!request.isForMainFrame() &&
-                !scheme.equals("http") && !scheme.equals("https")) {
+        if (!request.isForMainFrame()
+                && !scheme.equals("http")
+                && !scheme.equals("https")
+                && !scheme.equals("blob")) {
             // Block any malformed non-http(s) URIs. Webkit will already ignore things like market: URLs,
             // but not in all cases (malformed market: URIs, such as market:://... will still end up here).
             // (Note: data: URIs are automatically handled by webkit, and won't end up here either.)


### PR DESCRIPTION
a scheme 'blob:https://foo.bar/uu-uu-uu-id' is URL which refer to an
object which is already exist in memory. Therefore we don't need block
it.

to fix #1072