### PR TITLE
Remove setComposingRegion() in removeAutocompleteOnComposing

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
+++ b/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
@@ -456,7 +456,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
                     // Make the IME aware that we interrupted the setComposingText call,
                     // by having finishComposingText() send change notifications to the IME.
                     finishComposingText();
-                    setComposingRegion(composingStart, composingEnd);
                     return true;
                 }
                 return false;


### PR DESCRIPTION
We assumes IME will sync its state itself after we call
finishComposingText and setComposingRegion, this is not the
case for Google Zhuying and Japanese, remove them to avoid
making the experience even worse.