### PR TITLE
Remove Media scan when downloaded snackbar open fired.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -830,20 +830,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
                             .setAction(R.string.open, new View.OnClickListener() {
                                 @Override
                                 public void onClick(View view) {
-                                    if (TextUtils.isEmpty(downloadInfo.getMediaUri())) {
-                                        MediaScannerConnection.scanFile(MainActivity.this,
-                                                new String[]{Uri.parse(downloadInfo.getFileUri()).getPath()},
-                                                new String[]{downloadInfo.getMimeType()},
-                                                new MediaScannerConnection.OnScanCompletedListener() {
-
-                                                    @Override
-                                                    public void onScanCompleted(String path, Uri uri) {
-                                                        IntentUtils.intentOpenFile(MainActivity.this, path, downloadInfo.getMimeType());
-                                                    }
-                                                });
-                                    } else {
-                                        IntentUtils.intentOpenFile(view.getContext(), downloadInfo.getFileUri(), downloadInfo.getMimeType());
-                                    }
+                                    IntentUtils.intentOpenFile(MainActivity.this, downloadInfo.getFileUri(), downloadInfo.getMimeType());
                                 }
                             })
                             .show();


### PR DESCRIPTION
We now have FileProvider, this is not needed now. In the meanwhile
there's a bug here which path is provided but uri is wanted. This
raises some problems such as unencoded space is not a valid Uri.