### PR TITLE
Update firstLoadingUrlAfterResumed when url changes too

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -165,7 +165,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
         if (UrlUtils.isInternalErrorURL(url)) {
             return;
         }
-
+        firstLoadingUrlAfterResumed = url;
         urlView.setText(UrlUtils.stripUserInfo(url));
     }
 
@@ -817,7 +817,6 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
     @Override
     public void loadUrl(@NonNull final String url) {
-        firstLoadingUrlAfterResumed = url;
         updateURL(url);
         super.loadUrl(url);
     }


### PR DESCRIPTION
The previous implementation is ignoring cases when user browse
via url or when user have navigated to another page.
Hopefully this should be fixed with this commit.

Fixes #1192 