### PR TITLE
Set permission asked as true only if did get onRequestPermissionsResult

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -62,7 +62,6 @@ import org.mozilla.focus.web.WebViewProvider;
 import org.mozilla.focus.widget.FragmentListener;
 
 import java.io.File;
-import java.io.Serializable;
 import java.lang.ref.WeakReference;
 import java.util.List;
 
@@ -717,7 +716,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        permissionHandler.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        permissionHandler.onRequestPermissionsResult(this, requestCode, permissions, grantResults);
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -54,7 +54,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import org.mozilla.focus.R;
-import org.mozilla.focus.activity.MainActivity;
 import org.mozilla.focus.download.DownloadInfo;
 import org.mozilla.focus.download.DownloadInfoManager;
 import org.mozilla.focus.utils.FileChooseAction;
@@ -538,7 +537,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        permissionHandler.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        permissionHandler.onRequestPermissionsResult(getContext(), requestCode, permissions, grantResults);
     }
 
     /**

--- a/app/src/main/java/org/mozilla/focus/permission/PermissionHandler.java
+++ b/app/src/main/java/org/mozilla/focus/permission/PermissionHandler.java
@@ -16,7 +16,6 @@ import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AlertDialog;
 import android.view.View;
 
 import org.mozilla.focus.R;
@@ -102,8 +101,13 @@ public class PermissionHandler {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
         final String key = PERMISSION_PREFIX + permission;
         boolean exist = preferences.contains(key);
-        preferences.edit().putBoolean(key, true).apply();
         return !exist;
+    }
+
+    private void setPermissionAsked(Context context, String permission) {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        final String key = PERMISSION_PREFIX + permission;
+        preferences.edit().putBoolean(key, true).apply();
     }
 
     private void setAction(String permission, int actionId, Parcelable params) {
@@ -132,8 +136,9 @@ public class PermissionHandler {
         }
     }
 
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    public void onRequestPermissionsResult(Context context, int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (requestCode == actionId) {
+            setPermissionAsked(context, permissions[0]);
             if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 permissionHandle.doActionGranted(permission, actionId, params);
                 clearAction();

--- a/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotViewerActivity.java
+++ b/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotViewerActivity.java
@@ -17,7 +17,6 @@ import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcelable;
@@ -55,7 +54,6 @@ import java.util.ArrayList;
 import java.util.Calendar;
 
 import static com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.PAN_LIMIT_INSIDE;
-import static com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_CENTER_CROP;
 
 public class ScreenshotViewerActivity extends LocaleAwareAppCompatActivity implements View.OnClickListener, QueryHandler.AsyncDeleteListener {
 
@@ -264,7 +262,7 @@ public class ScreenshotViewerActivity extends LocaleAwareAppCompatActivity imple
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        permissionHandler.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        permissionHandler.onRequestPermissionsResult(this, requestCode, permissions, grantResults);
     }
 
     private void setupView(boolean existed) {


### PR DESCRIPTION
Otherwise, permission asked before flag is set to true when user kills
Activity.

Fixes #1319 