### PR TITLE
Make some static fields final

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -86,7 +86,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
     public static final String FRAGMENT_TAG = "browser";
 
-    private static int REQUEST_CODE_LOCATION_PERMISSION = 102;
+    private static final int REQUEST_CODE_LOCATION_PERMISSION = 102;
 
     private static final int ANIMATION_DURATION = 300;
     private static final String ARGUMENT_URL = "url";

--- a/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotViewerActivity.java
+++ b/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotViewerActivity.java
@@ -69,11 +69,11 @@ public class ScreenshotViewerActivity extends LocaleAwareAppCompatActivity imple
     private static final int ACTION_SHARE = ACTION_VIEW + 2;
     private static final int ACTION_DELETE = ACTION_VIEW + 3;
 
-    private static int REQUEST_CODE_VIEW_SCREENSHOT = 101;
-    private static int REQUEST_CODE_EDIT_SCREENSHOT = 102;
-    private static int REQUEST_CODE_SHARE_SCREENSHOT = 103;
-    private static int REQUEST_CODE_DELETE_SCREENSHOT = 104;
-    private static long DELAY_MILLIS_TO_SHOW_PROGRESS_BAR = 700;
+    private static final int REQUEST_CODE_VIEW_SCREENSHOT = 101;
+    private static final int REQUEST_CODE_EDIT_SCREENSHOT = 102;
+    private static final int REQUEST_CODE_SHARE_SCREENSHOT = 103;
+    private static final int REQUEST_CODE_DELETE_SCREENSHOT = 104;
+    private static final long DELAY_MILLIS_TO_SHOW_PROGRESS_BAR = 700;
 
     public static final void goScreenshotViewerActivityOnResult(Activity activity, Screenshot item) {
         Intent intent = new Intent(activity, ScreenshotViewerActivity.class);

--- a/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
@@ -29,8 +29,8 @@ import java.util.List;
 
 public class IntentUtils {
 
-    private static String MARKET_INTENT_URI_PACKAGE_PREFIX = "market://details?id=";
-    private static String EXTRA_BROWSER_FALLBACK_URL = "browser_fallback_url";
+    private static final String MARKET_INTENT_URI_PACKAGE_PREFIX = "market://details?id=";
+    private static final String EXTRA_BROWSER_FALLBACK_URL = "browser_fallback_url";
     public static final String EXTRA_IS_INTERNAL_REQUEST = "is_internal_request";
 
     /**


### PR DESCRIPTION
Adding final prohibits modification and allows initialization of
primitive and String fields at compile time instead of runtime in
clinit:

https://developer.android.com/training/articles/perf-tips.html#UseFinal

Found via error-prone.