### PR TITLE
remove DS_Store for git on Mac OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ l10n-repo/
 
 # Infer output
 infer-out/
+
+# MacOS X DS_Store
+.DS_Store


### PR DESCRIPTION
just to remove .DS_Store to avoid .DS_Store appear on git status