### PR TITLE
Handle onRequestPermissionsResult dismissed properly

### DIFF
--- a/app/src/main/java/org/mozilla/focus/permission/PermissionHandler.java
+++ b/app/src/main/java/org/mozilla/focus/permission/PermissionHandler.java
@@ -137,7 +137,8 @@ public class PermissionHandler {
     }
 
     public void onRequestPermissionsResult(Context context, int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (permissions == null || permissions.length == 0 || grantResults == null || grantResults.length == 0) {
+        if (permissions.length == 0 || grantResults.length == 0) {
+            clearAction();
             return;
         }
         if (requestCode == actionId) {


### PR DESCRIPTION
1. clearAction so the next prompt can show.
2. Remove unnecessary check since some fields are annotated