### PR TITLE
Ignore zh-CN in getEnabledLocales since we have zh-CN in our source c…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -371,6 +371,8 @@ def getEnabledLocales() {
 
     // en-US is the default language (in "values") and therefore needs to be added separately
     langs << "\"en-US\""
+    // Remove zh-CN since we have it in our source code but we currently don't want it packaged.
+    langs.remove("\"zh-CN\"")
 
     return langs
 }


### PR DESCRIPTION
…ode but don't package them.

Fixes #1394 