### PR TITLE
Try to resolve the intermittent UI test failures

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -548,3 +548,12 @@ task checkstyle(type: Checkstyle) {
 afterEvaluate {
     check.dependsOn 'findbugs', 'pmd', 'checkstyle'
 }
+
+task captureDeviceScreen(type: Exec) {
+    workingDir '..'
+    commandLine 'sh', 'tools/screenCapture.sh'
+}
+
+afterEvaluate {
+    connectedAndroidTest.dependsOn captureDeviceScreen
+}

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MainActivityTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MainActivityTest.java
@@ -22,10 +22,8 @@ public class MainActivityTest {
     public ActivityTestRule<MainActivity> activityRule = new ActivityTestRule<>(MainActivity.class);
 
     @Test
-        public void testAppStart() {
-
+    public void testAppStart() {
         onView(withId(R.id.root)).check(matches(isDisplayed()));
-
     }
 
 }

--- a/app/src/androidTest/java/org/mozilla/focus/test/runner/CustomTestRunner.java
+++ b/app/src/androidTest/java/org/mozilla/focus/test/runner/CustomTestRunner.java
@@ -1,6 +1,9 @@
 package org.mozilla.focus.test.runner;
 
+import android.app.KeyguardManager;
+import android.content.Context;
 import android.os.Bundle;
+import android.os.PowerManager;
 import android.support.test.runner.AndroidJUnitRunner;
 
 public class CustomTestRunner extends AndroidJUnitRunner {
@@ -16,5 +19,31 @@ public class CustomTestRunner extends AndroidJUnitRunner {
         // http://izmajlowiczl.blogspot.tw/2014/08/espresso-and-hidden-analytics-calls.html
         arguments.putString("disableAnalytics", "true");
         super.onCreate(arguments);
+    }
+
+    @Override
+    public void onStart() {
+        runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                Context applicationContext = CustomTestRunner.this.getTargetContext().getApplicationContext();
+
+                String tag = CustomTestRunner.class.getSimpleName();
+                unlockScreen(applicationContext, tag);
+                keepScreenAwake(applicationContext, tag);
+            }
+        });
+
+        super.onStart();
+    }
+
+    private void keepScreenAwake(Context applicationContext, String name) {
+        PowerManager power = (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
+        power.newWakeLock(PowerManager.FULL_WAKE_LOCK | PowerManager.ACQUIRE_CAUSES_WAKEUP | PowerManager.ON_AFTER_RELEASE, name).acquire();
+    }
+
+    private void unlockScreen(Context applicationContext, String name) {
+        KeyguardManager keyguard = (KeyguardManager) applicationContext.getSystemService(Context.KEYGUARD_SERVICE);
+        keyguard.newKeyguardLock(name).disableKeyguard();
     }
 }

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.mozilla.focus">
+
+    <!-- Put these permissions in the "debug" folder so it only gets merged into debug builds -->
+    <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+</manifest>

--- a/tools/screenCapture.sh
+++ b/tools/screenCapture.sh
@@ -1,5 +1,5 @@
 # Unlock emulator
 # adb shell input keyevent 82
-mkdir -p app/build/outputs/apk/focusWebkit/debug/
-adb shell screencap -p > app/build/outputs/apk/focusWebkit/debug/bootscreen.png
+mkdir -p app/build/outputs/apk/focusWebkit/test/
+adb shell screencap -p > app/build/outputs/apk/focusWebkit/test/app-focus-webkit-test.apk
 # Continue running some more tests

--- a/tools/screenCapture.sh
+++ b/tools/screenCapture.sh
@@ -1,0 +1,5 @@
+# Unlock emulator
+# adb shell input keyevent 82
+mkdir -p app/build/outputs
+adb shell screencap -p > app/build/outputs/bootscreen.png
+# Continue running some more tests

--- a/tools/screenCapture.sh
+++ b/tools/screenCapture.sh
@@ -1,5 +1,5 @@
 # Unlock emulator
 # adb shell input keyevent 82
-mkdir -p app/build/outputs
-adb shell screencap -p > app/build/outputs/bootscreen.png
+mkdir -p app/build/outputs/apk/focusWebkit/debug/
+adb shell screencap -p > app/build/outputs/apk/focusWebkit/debug/bootscreen.png
 # Continue running some more tests


### PR DESCRIPTION
`org.mozilla.focus.activity.MainActivityTest > testAppStart[nc-emulator(AVD) - 8.1.0] FAILED 
java.lang.RuntimeException: Waited for the root of the view hierarchy to have window focus and not request layout for 10 seconds. If you specified a non default root matcher, it may be picking a root that never takes focus. Root:
Root{application-window-token=android.view.ViewRootImpl$W@b3b9472, window-token=android.view.ViewRootImpl$W@b3b9472, has-window-focus=false, layout-params-type=1, layout-params-string=WM.LayoutParams{(0,0)(fillxfill) sim=#100 ty=1 fl=#81810100 pfl=0x20000 wanim=0x10302f6 needsMenuKey=2 colorMode=0}, decor-view-string=DecorView{id=-1
, visibility=VISIBLE, width=1080, height=1920, has-focus=true, has-focusable=true, has-window-focus=false, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=WM.LayoutParams{(0,0)(fillxfill) sim=#100 ty=1 fl=#81810100 pfl=0x20000 wanim=0x10302f6 need
sMenuKey=2 colorMode=0}, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0, child-count=2}}
:app:connectedFocusWebkitDebugAndroidTest FAILED`