### PR TITLE
Regression of #1303, resource placeholder not working, closes #1409

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,5 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+android.enableAapt2=false


### PR DESCRIPTION
We upgrade build tools to latest version, android-gradle plugin 3.x above uses aapt2, which compile resource into binary format and breaks plugin "gradle.plugin.android-text-resolver" to patch the resource file.

Temporary solution is to disable aapt2, and we need another follow up issue to track.