### PR TITLE
Skip callback by mostOldCallbacksHaveFinished cause ProgressBar and reload button state inconsistent

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -97,8 +97,6 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
     private final static int NONE = -1;
     private int systemVisibility = NONE;
 
-    private String firstLoadingUrlAfterResumed = null;
-
     public static BrowserFragment create(@NonNull String url) {
         Bundle arguments = new Bundle();
         arguments.putString(ARGUMENT_URL, url);
@@ -747,7 +745,6 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
     @Override
     public void loadUrl(@NonNull final String url) {
-        firstLoadingUrlAfterResumed = url;
         updateURL(url);
         super.loadUrl(url);
     }
@@ -902,7 +899,6 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
     class WebviewCallback implements IWebView.Callback {
 
         String failingUrl;
-        private boolean mostOldCallbacksHaveFinished = false;
         // Some url may have two onPageFinished for the same url. filter them out to avoid
         // adding twice to the history.
         private String lastInsertedUrl = null;
@@ -912,19 +908,6 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
         @Override
         public void onPageStarted(final String url) {
-            // This mostOldCallbacksHaveFinished flag sort of works like onPageCommitVisible.
-            // There are some callback triggers that are fired due to Webview.restoreState()
-            // or last webview loading that are not finished. As a quick fix we filtered these
-            // onPageFinished and onProgress out by only consuming the callbacks after our
-            // targeted url has fired a onPageStarted. This is assuming we will always have a
-            // such onPageStarted call back after webview.loadUrl() which I am not certain is
-            // guaranteed. We filtered out these since they are having some properties such as:
-            // the getTitle() returned here is incomplete. This is most likely the
-            // onPageFinished events that are fired by didFinishNavigation
-            // See: https://stackoverflow.com/a/46298285/3591480
-            if (firstLoadingUrlAfterResumed != null && UrlUtils.urlsMatchExceptForTrailingSlash(firstLoadingUrlAfterResumed, url)) {
-                mostOldCallbacksHaveFinished = true;
-            }
             lastInsertedUrl = null;
             loadedUrl = null;
 
@@ -945,9 +928,6 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
         @Override
         public void onPageFinished(boolean isSecure) {
-            if (!mostOldCallbacksHaveFinished) {
-                return;
-            }
             // The URL which is supplied in onPageFinished() could be fake (see #301), but webview's
             // URL is always correct _except_ for error pages
             updateUrlFromWebView();
@@ -975,9 +955,6 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
         @Override
         public void onProgress(int progress) {
-            if (!mostOldCallbacksHaveFinished) {
-                return;
-            }
             final IWebView webView = getWebView();
             if (webView != null) {
                 final String currentUrl = webView.getUrl();
@@ -1110,10 +1087,6 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
         // See issue1064 and issue1150.
         @Override
         public void onReceivedTitle(WebView view, String title) {
-            if (!mostOldCallbacksHaveFinished) {
-                return;
-            }
-
             if (!BrowserFragment.this.getUrl().equals(view.getUrl())) {
                 updateURL(view.getUrl());
             }


### PR DESCRIPTION
Revert: 79d7f54da81beefe7c70127124c266f74e1efc7e, closes #1232 