### PR TITLE
Fix StrictMode:SlowCall; Pops out after upgrade sdk to 27

### DIFF
--- a/app/src/main/java/org/mozilla/focus/FocusApplication.java
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.java
@@ -49,10 +49,10 @@ public class FocusApplication extends LocaleAwareApplication {
         final StrictMode.VmPolicy.Builder vmPolicyBuilder = new StrictMode.VmPolicy.Builder().detectAll();
 
         if (AppConstants.isBetaBuild()) {
-            threadPolicyBuilder.penaltyDialog();
+            threadPolicyBuilder.penaltyLog().penaltyDialog();
             vmPolicyBuilder.penaltyLog();
         } else { // Dev/debug build
-            threadPolicyBuilder.penaltyDialog();
+            threadPolicyBuilder.penaltyLog().penaltyDialog();
             // We want only penaltyDeath(), but penaltLog() is needed print a stacktrace when a violation happens
             vmPolicyBuilder.penaltyLog().penaltyDeath();
         }

--- a/app/src/main/java/org/mozilla/focus/history/BrowsingHistoryManager.java
+++ b/app/src/main/java/org/mozilla/focus/history/BrowsingHistoryManager.java
@@ -6,6 +6,7 @@
 package org.mozilla.focus.history;
 
 import android.content.ContentResolver;
+import android.content.ContentValues;
 import android.content.Context;
 import android.database.ContentObserver;
 import android.net.Uri;
@@ -94,8 +95,14 @@ public class BrowsingHistoryManager {
         }
     }
 
-    public void insert(Site site, AsyncInsertListener listener) {
-        mQueryHandler.startInsert(QueryHandler.SITE_TOKEN, listener, BrowsingHistory.CONTENT_URI, QueryHandler.getContentValuesFromSite(site));
+    public void insert(final Site site, final AsyncInsertListener listener) {
+        mQueryHandler.postWorker(new Runnable() {
+            @Override
+            public void run() {
+                final ContentValues contentValues = QueryHandler.getContentValuesFromSite(site);
+                mQueryHandler.startInsert(QueryHandler.SITE_TOKEN, listener, BrowsingHistory.CONTENT_URI, contentValues);
+            }
+        });
     }
 
     public void delete(long id, AsyncDeleteListener listener) {
@@ -106,8 +113,14 @@ public class BrowsingHistoryManager {
         mQueryHandler.startDelete(QueryHandler.SITE_TOKEN, new AsyncDeleteWrapper(-1, listener), BrowsingHistory.CONTENT_URI, "1", null);
     }
 
-    public void updateLastEntry(Site site, AsyncUpdateListener listener) {
-        mQueryHandler.startUpdate(QueryHandler.SITE_TOKEN, listener, BrowsingHistory.CONTENT_URI, QueryHandler.getContentValuesFromSite(site), BrowsingHistory._ID + " = ( SELECT " + BrowsingHistory._ID + " FROM " + HistoryContract.TABLE_NAME + " WHERE " + BrowsingHistory.URL + " = ? ORDER BY " + BrowsingHistory.LAST_VIEW_TIMESTAMP + " DESC)", new String[]{site.getUrl()});
+    public void updateLastEntry(final Site site, final AsyncUpdateListener listener) {
+        mQueryHandler.postWorker(new Runnable() {
+            @Override
+            public void run() {
+                final ContentValues contentValues = QueryHandler.getContentValuesFromSite(site);
+                mQueryHandler.startUpdate(QueryHandler.SITE_TOKEN, listener, BrowsingHistory.CONTENT_URI, contentValues, BrowsingHistory._ID + " = ( SELECT " + BrowsingHistory._ID + " FROM " + HistoryContract.TABLE_NAME + " WHERE " + BrowsingHistory.URL + " = ? ORDER BY " + BrowsingHistory.LAST_VIEW_TIMESTAMP + " DESC)", new String[]{site.getUrl()});
+            }
+        });
     }
 
     public void query(int offset, int limit, AsyncQueryListener listener) {

--- a/app/src/main/java/org/mozilla/focus/provider/QueryHandler.java
+++ b/app/src/main/java/org/mozilla/focus/provider/QueryHandler.java
@@ -12,6 +12,8 @@ import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
 
 import org.mozilla.focus.history.model.Site;
 import org.mozilla.focus.screenshot.model.Screenshot;
@@ -28,6 +30,7 @@ public class QueryHandler extends AsyncQueryHandler {
 
     public static final int SITE_TOKEN = 1;
     public static final int SCREENSHOT_TOKEN = 2;
+    private Handler mWorkerHandler;
 
     public static final class AsyncDeleteWrapper {
 
@@ -58,6 +61,16 @@ public class QueryHandler extends AsyncQueryHandler {
 
     public QueryHandler(ContentResolver resolver) {
         super(resolver);
+    }
+
+    @Override
+    protected Handler createHandler(Looper looper) {
+        mWorkerHandler = super.createHandler(looper);
+        return mWorkerHandler;
+    }
+
+    public void postWorker(Runnable r) {
+        mWorkerHandler.post(r);
     }
 
     @Override


### PR DESCRIPTION
StrictMode: StrictMode policy violation; ~duration=2 ms: android.os.StrictMode$StrictModeCustomViolation: policy=196671 violation=8 msg=Compression of a bitmap is slow
StrictMode:    at android.os.StrictMode$AndroidBlockGuardPolicy.onCustomSlowCall(StrictMode.java:1399)
StrictMode:    at android.os.StrictMode.noteSlowCall(StrictMode.java:2342)
StrictMode:    at android.graphics.Bitmap.compress(Bitmap.java:1245)
StrictMode:    at org.mozilla.focus.provider.QueryHandler.bitmapToBytes(QueryHandler.java:201)
StrictMode:    at org.mozilla.focus.provider.QueryHandler.getContentValuesFromSite(QueryHandler.java:156)
StrictMode:    at org.mozilla.focus.history.BrowsingHistoryManager$1.run(BrowsingHistoryManager.java:102)
StrictMode:    at android.os.Handler.handleCallback(Handler.java:790)
StrictMode:    at android.os.Handler.dispatchMessage(Handler.java:99)
StrictMode:    at android.os.Looper.loop(Looper.java:164)
StrictMode:    at android.app.ActivityThread.main(ActivityThread.java:6494)
StrictMode:    at java.lang.reflect.Method.invoke(Native Method)
StrictMode:    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
StrictMode:    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)