### PR TITLE
Check querytask is non-null before canceling it.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/urlinput/UrlInputPresenter.java
+++ b/app/src/main/java/org/mozilla/focus/urlinput/UrlInputPresenter.java
@@ -48,7 +48,7 @@ public class UrlInputPresenter implements UrlInputContract.Presenter {
     public void setView(UrlInputContract.View view) {
         this.view = view;
         // queryTask holds a WeakReference to view, cancel the task too.
-        if (view == null) {
+        if (view == null && queryTask != null) {
             queryTask.cancel(false);
         }
     }


### PR DESCRIPTION
Fixes #1457 on v1.0-dev