### PR TITLE
Modify MainMediator#showBrowserScreen() signature

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -115,8 +115,9 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
                     pendingUrl = url;
                     this.mediator.showFirstRun();
                 } else {
-                    boolean isFromInternal = intent.getBooleanExtra(IntentUtils.EXTRA_IS_INTERNAL_REQUEST, false);
-                    this.mediator.showBrowserScreen(url, isFromInternal ? false : true);
+                    boolean openInNewTab = intent.getBooleanExtra(IntentUtils.EXTRA_OPEN_NEW_TAB,
+                            false);
+                    this.mediator.showBrowserScreen(url, openInNewTab);
                 }
             } else {
                 if (Settings.getInstance(this).shouldShowFirstrun()) {
@@ -238,8 +239,8 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
             // Unless we're trying to show the firstrun screen, in which case we leave it pending until
             // firstrun is dismissed.
             final SafeIntent intent = new SafeIntent(getIntent());
-            boolean isFromInternal = intent != null && intent.getBooleanExtra(IntentUtils.EXTRA_IS_INTERNAL_REQUEST, false);
-            this.mediator.showBrowserScreen(pendingUrl, isFromInternal ? false : true);
+            boolean openInNewTab = intent.getBooleanExtra(IntentUtils.EXTRA_OPEN_NEW_TAB, false);
+            this.mediator.showBrowserScreen(pendingUrl, openInNewTab);
             pendingUrl = null;
         }
     }
@@ -285,7 +286,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
 
     private void postSurveyNotification() {
         Intent intent = IntentUtils.createInternalOpenUrlIntent(this,
-                getSurveyUrl());
+                getSurveyUrl(), true);
         PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent,
                 PendingIntent.FLAG_ONE_SHOT);
 
@@ -648,6 +649,11 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
     public void onNotified(@NonNull Fragment from, @NonNull TYPE type, @Nullable Object payload) {
         switch (type) {
             case OPEN_URL:
+                if ((payload != null) && (payload instanceof String)) {
+                    this.mediator.showBrowserScreen(payload.toString(), true);
+                }
+                break;
+            case LOAD_URL:
                 if ((payload != null) && (payload instanceof String)) {
                     this.mediator.showBrowserScreen(payload.toString(), false);
                 }

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -219,6 +219,7 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
                 }
             }
 
+
             private void actionDownloadGranted(Parcelable parcelable) {
                 Download download = (Download) parcelable;
                 queueDownload(download);
@@ -447,7 +448,7 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         // restore WebView state
         if (savedInstanceState == null) {
             if (!TextUtils.isEmpty(pendingUrl)) {
-                loadUrl(pendingUrl);
+                loadUrl(pendingUrl, true);
                 pendingUrl = null;
             }
         } else {
@@ -870,10 +871,14 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         }
     }
 
-    public void loadUrl(@NonNull final String url) {
+    public void loadUrl(@NonNull final String url, boolean openNewTab) {
         updateURL(url);
         if (UrlUtils.isUrl(url)) {
-            tabsSession.addTab(url);
+            if (openNewTab) {
+                tabsSession.addTab(url);
+            } else {
+                tabsSession.getCurrentTab().getTabView().loadUrl(url);
+            }
         } else if (AppConstants.isDevBuild()) {
             // throw exception to highlight this issue, except release build.
             throw new RuntimeException("trying to open a invalid url: " + url);

--- a/app/src/main/java/org/mozilla/focus/urlinput/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/urlinput/UrlInputFragment.java
@@ -223,7 +223,7 @@ public class UrlInputFragment extends Fragment implements UrlInputContract.View,
     private void openUrl(String url) {
         final Activity activity = getActivity();
         if (activity instanceof FragmentListener) {
-            ((FragmentListener) activity).onNotified(this, FragmentListener.TYPE.OPEN_URL, url);
+            ((FragmentListener) activity).onNotified(this, FragmentListener.TYPE.LOAD_URL, url);
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/utils/DialogUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/DialogUtils.java
@@ -63,7 +63,7 @@ public class DialogUtils {
             @Override
             public void onClick(View v) {
                 Settings.getInstance(context).setShareAppDialogDidShow();
-                IntentUtils.openUrl(context, context.getString(R.string.rate_app_feedback_url));
+                IntentUtils.openUrl(context, context.getString(R.string.rate_app_feedback_url), true);
                 if (dialog != null) {
                     dialog.dismiss();
                 }

--- a/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
@@ -33,6 +33,7 @@ public class IntentUtils {
     private static final String MARKET_INTENT_URI_PACKAGE_PREFIX = "market://details?id=";
     private static final String EXTRA_BROWSER_FALLBACK_URL = "browser_fallback_url";
     public static final String EXTRA_IS_INTERNAL_REQUEST = "is_internal_request";
+    public static final String EXTRA_OPEN_NEW_TAB = "open_new_tab";
 
     /**
      * Find and open the appropriate app for a given Uri. If appropriate, let the user select between
@@ -191,17 +192,19 @@ public class IntentUtils {
         context.startActivity(pageView);
     }
 
-    public static void openUrl(Context context, String url) {
-        context.startActivity(createInternalOpenUrlIntent(context, url));
+    @SuppressWarnings({"SameParameterValue", "WeakerAccess"})
+    public static void openUrl(Context context, String url, boolean openInNewTab) {
+        context.startActivity(createInternalOpenUrlIntent(context, url, openInNewTab));
     }
 
-    public static Intent createInternalOpenUrlIntent(Context context, String url) {
+    public static Intent createInternalOpenUrlIntent(Context context, String url, boolean openInNewTab) {
         Intent intent = new Intent(Intent.ACTION_VIEW,
                 Uri.parse(url),
                 context,
                 MainActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.putExtra(IntentUtils.EXTRA_IS_INTERNAL_REQUEST, true);
+        intent.putExtra(IntentUtils.EXTRA_OPEN_NEW_TAB, openInNewTab);
         return intent;
     }
 }

--- a/app/src/main/java/org/mozilla/focus/widget/FragmentListener.java
+++ b/app/src/main/java/org/mozilla/focus/widget/FragmentListener.java
@@ -17,7 +17,8 @@ public interface FragmentListener {
     enum TYPE {
         FRAGMENT_STARTED, // payload is the fragment tag
         FRAGMENT_STOPPED, // payload is the fragment tag
-        OPEN_URL, // payload is url in String
+        LOAD_URL, // load url in current tab. payload is url in String
+        OPEN_URL, // open url in new tab, payload is url in String
         OPEN_PREFERENCE, // no payload
         SHOW_URL_INPUT, // no payload
         SHOW_HOME, // no payload


### PR DESCRIPTION
The 2nd param of MainMediator#showBrowserScreen() is changed from "clearHistory" to "openInNewTab".

Why clearHistory param:
In prev version, history is always cleared if ACTION_VIEW is sent from 3rd party apps. However, we can't do this if ACTION_VIEW is sent by our self (e.g. open our feedback page, etc), which will make user unable to navigate back to the previous page.

With multi-tab supported, we can decide to open url in a new tab without clearing browsing stack. So clearHistory is not needed anymore.