### PR TITLE
Don't cleanup when view is destroyed

### DIFF
--- a/app/src/main/java/org/mozilla/focus/tabs/Tab.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/Tab.java
@@ -122,8 +122,6 @@ public class Tab {
         setTabViewClient(null);
 
         if (tabView != null) {
-            tabView.cleanup();
-
             // ensure the view not bind to parent
             detach();
 


### PR DESCRIPTION
The only entry point of cleanup was erase which was dangling in v1.0. So we won't call cleanup in 2.0 too.

See: https://github.com/mozilla-tw/Rocket/blob/a591325d6e9be68f81ccdfe3853220273590288b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java#L738

Fixes #1475 