### PR TITLE
Issues/1522

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/DefaultBrowserTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/DefaultBrowserTest.java
@@ -28,6 +28,7 @@ import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
 import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
 import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withParent;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.Is.is;
@@ -68,7 +69,7 @@ public class DefaultBrowserTest {
         final String prefName = activity.getString(R.string.pref_key_default_browser);
 
         // Click on the menu item
-        onView(withId(R.id.btn_menu)).perform(click());
+        onView(allOf(withId(R.id.btn_menu), withParent(withId(R.id.home_screen_menu_button)))).perform(click());
 
         // Click on Settings
         onView(withId(R.id.menu_preferences)).perform(click());

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -108,6 +108,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
 
         if (savedInstanceState == null) {
             if (Intent.ACTION_VIEW.equals(intent.getAction())) {
+                mediator.setStartedFromExternalApp();
                 final String url = intent.getDataString();
 
                 BrowsingSession.getInstance().loadCustomTabConfig(this, intent);
@@ -640,10 +641,11 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
         if (!safeForFragmentTransactions) {
             return;
         }
-        if (this.mediator.handleBackKey()) {
+        // BrowserFragment is at top
+        if (this.mediator.getTopHomeFragmet() == null && getVisibleBrowserFragment().onBackPressed()) {
             return;
         }
-        if (getVisibleBrowserFragment().onBackPressed()) {
+        if (this.mediator.handleBackKey()) {
             return;
         }
         super.onBackPressed();
@@ -680,7 +682,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
                 if (payload != null && payload instanceof Boolean) {
                     animated = (Boolean) payload;
                 }
-                this.mediator.showHomeScreen(animated);
+                this.mediator.showHomeScreen(animated, false);
                 break;
             case SHOW_MENU:
                 this.showMenu();

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -85,15 +85,12 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
 
     private MainMediator mediator;
     private boolean safeForFragmentTransactions = false;
-    private boolean hasPendingScreenCaptureTask = false;
     private DialogFragment mDialogFragment;
 
     private BroadcastReceiver uiMessageReceiver;
     private static boolean sIsNewCreated = true;
 
     private TabsSession tabsSession;
-
-    private static final int ACTION_CAPTURE = 0;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -525,6 +525,12 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
         }
     }
 
+    @Override
+    public void onDestroy() {
+        tabsSession.destroy();
+        super.onDestroy();
+    }
+
     private void onPreferenceClicked() {
         openPreferences();
     }

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -559,7 +559,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
     }
 
     private BrowserFragment getBrowserFragment() {
-        return (BrowserFragment) getSupportFragmentManager().findFragmentByTag(BrowserFragment.FRAGMENT_TAG);
+        return (BrowserFragment) getSupportFragmentManager().findFragmentById(R.id.browser);
     }
 
     private void onBackClicked(final BrowserFragment browserFragment) {
@@ -643,6 +643,9 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
         if (this.mediator.handleBackKey()) {
             return;
         }
+        if (getVisibleBrowserFragment().onBackPressed()) {
+            return;
+        }
         super.onBackPressed();
     }
 
@@ -724,16 +727,6 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
 
     public FirstrunFragment createFirstRunFragment() {
         return FirstrunFragment.create();
-    }
-
-    public BrowserFragment createBrowserFragment(@NonNull String url) {
-        BrowserFragment fragment = BrowserFragment.create(url);
-        return fragment;
-    }
-
-    public BrowserFragment createBrowserFragmentForTab(@NonNull String tabId) {
-        BrowserFragment fragment = BrowserFragment.createForTabId(tabId);
-        return fragment;
     }
 
     public UrlInputFragment createUrlInputFragment(@Nullable String url) {

--- a/app/src/main/java/org/mozilla/focus/activity/MainMediator.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainMediator.java
@@ -30,10 +30,6 @@ public class MainMediator {
             BrowserFragment.FRAGMENT_TAG
     };
 
-    // To indicate the Transaction is to hoist home fragment to user visible area.
-    // This transaction could be wiped if user try to see browser fragment again.
-    private final static String HOIST_HOME_FRAGMENT = "_hoist_home_fragment_";
-
     private final MainActivity activity;
 
     public MainMediator(@NonNull MainActivity activity) {

--- a/app/src/main/java/org/mozilla/focus/activity/MainMediator.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainMediator.java
@@ -34,7 +34,6 @@ public class MainMediator {
 
     public MainMediator(@NonNull MainActivity activity) {
         this.activity = activity;
-        activity.getSupportFragmentManager().addOnBackStackChangedListener(backStackChangedListener);
     }
 
     public void showHomeScreen() {
@@ -206,34 +205,6 @@ public class MainMediator {
         if (homeFragment != null && homeFragment.isVisible()) {
             homeFragment.toggleFakeUrlInput(visible);
         }
-    }
-
-    /**
-     * refresh HomeFragment Top sites, if HomeFragment is TopFragment
-     */
-    private void refreshHomeFragment() {
-        final Fragment topFragment = getTopHomeFragmet();
-        if (topFragment != null) {
-            topFragment.onResume();
-        }
-    }
-
-    private int lastBackStackEntryCount = 0;
-    public FragmentManager.OnBackStackChangedListener backStackChangedListener = new FragmentManager.OnBackStackChangedListener() {
-        public void onBackStackChanged() {
-            final FragmentManager fragmentManager = activity.getSupportFragmentManager();
-            if (fragmentManager != null) {
-                int currentBackStackEntryCount = fragmentManager.getBackStackEntryCount();
-                if (isPopStack(currentBackStackEntryCount)) {
-                    refreshHomeFragment();
-                }
-                lastBackStackEntryCount = currentBackStackEntryCount;
-            }
-        }
-    };
-
-    private boolean isPopStack(int BackStackEntryCount) {
-        return lastBackStackEntryCount > BackStackEntryCount;
     }
 
     public void setStartedFromExternalApp() {

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -800,38 +800,13 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         geolocationCallback = null;
     }
 
-    private boolean isStartedFromExternalApp() {
-        final Activity activity = getActivity();
-        if (activity == null) {
-            return false;
-        }
-
-        // No SafeIntent needed here because intent.getAction() is safe (SafeIntent simply calls intent.getAction()
-        // without any wrapping):
-        final Intent intent = activity.getIntent();
-        boolean isFromInternal = intent != null && intent.getBooleanExtra(IntentUtils.EXTRA_IS_INTERNAL_REQUEST, false);
-        return intent != null && Intent.ACTION_VIEW.equals(intent.getAction()) && !isFromInternal;
-    }
-
     public boolean onBackPressed() {
-        if (canGoBack()) {
+        boolean ret = canGoBack();
+        if (ret) {
             // Go back in web history
             goBack();
-        } else {
-            if (isStartedFromExternalApp()) {
-                // We have been started from a VIEW intent. Go back to the previous app immediately (No erase).
-                // However we need to finish the current session so that the custom tab config gets
-                // correctly cleared:
-                // FIXME: does Zerda need this?
-                BrowsingSession.getInstance().clearCustomTabConfig();
-                getActivity().finish();
-            } else {
-                // let parent to decide for this Fragment
-                return false;
-            }
         }
-
-        return true;
+        return ret;
     }
 
     public void setBlockingEnabled(boolean enabled) {

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -103,9 +103,6 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
 
     private static final int ANIMATION_DURATION = 300;
 
-    private static final String ARGUMENT_URL = "url";
-    private static final String ARGUMENT_TAB_ID = "tab_id";
-
     private static final int SITE_GLOBE = 0;
     private static final int SITE_LOCK = 1;
 
@@ -114,34 +111,10 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
 
     private DownloadCallback downloadCallback = new DownloadCallback();
 
-    public static BrowserFragment create(@NonNull String url) {
-        Bundle arguments = new Bundle();
-        arguments.putString(ARGUMENT_URL, url);
-
-        BrowserFragment fragment = new BrowserFragment();
-        fragment.setArguments(arguments);
-
-        return fragment;
-    }
-
-    public static BrowserFragment createForTabId(@NonNull String tabId) {
-        Bundle arguments = new Bundle();
-        arguments.putString(ARGUMENT_TAB_ID, tabId);
-
-        BrowserFragment fragment = new BrowserFragment();
-        fragment.setArguments(arguments);
-
-        return fragment;
-    }
-
     private static final int BUNDLE_MAX_SIZE = 300 * 1000; // 300K
 
     private ViewGroup webViewSlot;
     private TabsSession tabsSession;
-
-    /* If fragment exists but no WebView to use, store url here if there is any loadUrl requirement */
-    protected String pendingUrl = null;
-    protected String pendingTabId = null;
 
     private View backgroundView;
     private TransitionDrawable backgroundTransition;
@@ -378,30 +351,12 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         }
     }
 
-    public String getInitialUrl() {
-        return getArguments().getString(ARGUMENT_URL);
-    }
-
-    public String getInitialTabId() {
-        return getArguments().getString(ARGUMENT_TAB_ID);
-    }
-
     private void updateURL(final String url) {
         if (UrlUtils.isInternalErrorURL(url)) {
             return;
         }
 
         urlView.setText(UrlUtils.stripUserInfo(url));
-    }
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        if (savedInstanceState == null) {
-            // save the link until we really have view to open
-            pendingUrl = getInitialUrl();
-            pendingTabId = getInitialTabId();
-        }
     }
 
     @Override
@@ -467,16 +422,7 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         super.onViewCreated(container, savedInstanceState);
 
         // restore WebView state
-        if (savedInstanceState == null) {
-            if (!TextUtils.isEmpty(pendingUrl)) {
-                loadUrl(pendingUrl, true);
-                pendingUrl = null;
-            }
-            if (!TextUtils.isEmpty(pendingTabId)) {
-                tabsSession.switchToTab(pendingTabId);
-                pendingTabId = null;
-            }
-        } else {
+        if (savedInstanceState != null) {
             // Fragment was destroyed
             // FIXME: Obviously, only restore current tab is not enough
             if (tabsSession.getCurrentTab() != null) {
@@ -911,6 +857,12 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         } else if (AppConstants.isDevBuild()) {
             // throw exception to highlight this issue, except release build.
             throw new RuntimeException("trying to open a invalid url: " + url);
+        }
+    }
+
+    public void loadTab(final String tabId) {
+        if (!TextUtils.isEmpty(tabId)) {
+            tabsSession.switchToTab(tabId);
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -610,7 +610,6 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
 
     @Override
     public void onDestroy() {
-        tabsSession.destroy();
         tabsSession.removeTabsViewListener(this.tabsContentListener);
         tabsSession.removeTabsChromeListener(this.tabsContentListener);
         super.onDestroy();

--- a/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
@@ -32,7 +32,6 @@ public class IntentUtils {
 
     private static final String MARKET_INTENT_URI_PACKAGE_PREFIX = "market://details?id=";
     private static final String EXTRA_BROWSER_FALLBACK_URL = "browser_fallback_url";
-    public static final String EXTRA_IS_INTERNAL_REQUEST = "is_internal_request";
     public static final String EXTRA_OPEN_NEW_TAB = "open_new_tab";
 
     /**
@@ -203,7 +202,6 @@ public class IntentUtils {
                 context,
                 MainActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        intent.putExtra(IntentUtils.EXTRA_IS_INTERNAL_REQUEST, true);
         intent.putExtra(IntentUtils.EXTRA_OPEN_NEW_TAB, openInNewTab);
         return intent;
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,13 +5,15 @@
 <!-- Ignore MergeRootFrame: we need a single container View where we can attach fragments, so
      we definitely need to keep this FrameLayout (i.e. we can't <merge> here). -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:ignore="MergeRootFrame">
-
+    <fragment android:name="org.mozilla.focus.fragment.BrowserFragment"
+        android:id="@+id/browser"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
     <FrameLayout
         android:id="@+id/container"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_homescreen_item_menu_button.xml
+++ b/app/src/main/res/layout/fragment_homescreen_item_menu_button.xml
@@ -9,6 +9,7 @@
     android:layout_gravity="center">
 
     <org.mozilla.focus.widget.EqualDistributeRow xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/home_screen_menu_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/fixed_menu_horizontal_margin"


### PR DESCRIPTION
Fixes #1522
BrowserFragment is now sharing the lifecycle to MainActivity.
In the meanwhile the TabsSession destroy is delayed to:
1. Match the creation lifecycle (MainActivity)
2. Avoid too aggressive destroy which make users might need to reload all pages (when BrowserFragment is poped.)