### PR TITLE
[TabTray] Fix some tab tray issues

### DIFF
--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayAdapter.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayAdapter.java
@@ -116,6 +116,11 @@ public class TabTrayAdapter extends RecyclerView.Adapter<TabTrayAdapter.ViewHold
     }
 
     private void loadFavicon(Tab tab, final ViewHolder holder) {
+        String uri = tab.getUrl();
+        if (TextUtils.isEmpty(uri)) {
+            return;
+        }
+
         RequestOptions options = new RequestOptions()
                 .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                 .dontAnimate();


### PR DESCRIPTION
1. When onBindViewHolder() is triggered by notifyItemChanged(), tab view may be in the progress to retrieve web view title, and will temporarily return a empty string, if we update title at that moment, tab title may fallback to default title for a very short period.
2. Do not load favicon if the tab url is empty