### PR TITLE
api: onTabHoist rename to onFocusChanged

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -1076,7 +1076,7 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         private ValueAnimator tabTransitionAnimator;
 
         @Override
-        public void onTabHoist(@Nullable final Tab tab, @Factor int factor) {
+        public void onFocusChanged(@Nullable final Tab tab, @Factor int factor) {
             if (tab == null) {
                 if (factor == FACTOR_NO_FOCUS) {
                     notifyParent(FragmentListener.TYPE.SHOW_HOME, null);

--- a/app/src/main/java/org/mozilla/focus/tabs/TabsChromeListener.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/TabsChromeListener.java
@@ -56,13 +56,13 @@ public interface TabsChromeListener {
     void onReceivedIcon(@NonNull Tab tab, Bitmap icon);
 
     /**
-     * Notify the host application a tab becomes 'current tab'. It usually happens when adding,
+     * Notify the host application a tab becomes 'focused tab'. It usually happens when adding,
      * removing or switching tabs.
      *
-     * @param tab    The tab becomes current tab
-     * @param factor the potential factor which cause this hoist-event
+     * @param tab    The tab becomes focused, null means there is no focused tab
+     * @param factor the potential factor which cause this focus-change-event
      */
-    void onTabHoist(@Nullable Tab tab, @Factor int factor);
+    void onFocusChanged(@Nullable Tab tab, @Factor int factor);
 
     /**
      * Notify the host application the total tab counts changed.

--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayFragment.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayFragment.java
@@ -656,7 +656,7 @@ public class TabTrayFragment extends DialogFragment implements TabTrayContract.V
         }
 
         @Override
-        public void onTabHoist(@Nullable Tab tab, @Factor int factor) {
+        public void onFocusChanged(@Nullable Tab tab, @Factor int factor) {
         }
 
         @Override

--- a/app/src/test/java/org/mozilla/focus/tabs/TabsSessionTest.java
+++ b/app/src/test/java/org/mozilla/focus/tabs/TabsSessionTest.java
@@ -202,39 +202,39 @@ public class TabsSessionTest {
 
     @Test
     public void testAddTab5() {
-        // Add a tab from internal and hoist it. onTabHoist should be invoked once
+        // Add a tab from internal and focus it. onFocusChanged should be invoked once
         final TabsChromeListener spy0 = spy(new DefaultChromeListener() {
-            public void onTabHoist(@NonNull Tab tab, @Factor int factor) {
+            public void onFocusChanged(@Nullable Tab tab, @Factor int factor) {
                 Assert.assertEquals(tab.getUrl(), "url0");
             }
         });
         session.addTabsChromeListener(spy0);
         final String tabId0 = session.addTab(null, "url0", false, true);
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
-        verify(spy0, times(1)).onTabHoist(any(Tab.class), eq(TabsChromeListener.FACTOR_TAB_ADDED));
+        verify(spy0, times(1)).onFocusChanged(any(Tab.class), eq(TabsChromeListener.FACTOR_TAB_ADDED));
         Assert.assertEquals(session.getFocusTab().getId(), tabId0);
         session.removeTabsChromeListener(spy0);
 
-        // Add a tab from external. onTabHoist should be invoked
+        // Add a tab from external. onFocusChanged should be invoked
         final TabsChromeListener spy1 = spy(new DefaultChromeListener() {
-            public void onTabHoist(@NonNull Tab tab, @Factor int factor) {
+            public void onFocusChanged(@Nullable Tab tab, @Factor int factor) {
                 Assert.assertEquals(tab.getUrl(), "url1");
             }
         });
         session.addTabsChromeListener(spy1);
         final String tabId1 = session.addTab(null, "url1", true, false);
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
-        verify(spy1, times(1)).onTabHoist(any(Tab.class), eq(TabsChromeListener.FACTOR_TAB_ADDED));
+        verify(spy1, times(1)).onFocusChanged(any(Tab.class), eq(TabsChromeListener.FACTOR_TAB_ADDED));
         Assert.assertEquals(session.getFocusTab().getId(), tabId1);
         session.removeTabsChromeListener(spy1);
 
-        // Add a tab from internal, but don't hoist it.
-        // Add a tab from external. onTabHoist should be invoked
+        // Add a tab from internal, but don't focus it.
+        // Add a tab from external. onFocusChanged should be invoked
         final TabsChromeListener spy2 = spy(TabsChromeListener.class);
         session.addTabsChromeListener(spy2);
         session.addTab(null, "url2", false, false);
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
-        verify(spy2, times(0)).onTabHoist(any(Tab.class), anyInt());
+        verify(spy2, times(0)).onFocusChanged(any(Tab.class), anyInt());
         Assert.assertEquals(session.getFocusTab().getId(), tabId1); // focus should not be changed
         session.removeTabsChromeListener(spy2);
     }
@@ -545,7 +545,7 @@ public class TabsSessionTest {
         }
 
         @Override
-        public void onTabHoist(@NonNull Tab tab, @Factor int factor) {
+        public void onFocusChanged(@Nullable Tab tab, @Factor int factor) {
 
         }
 


### PR DESCRIPTION
After evolution of implementation, the original naming `onTabHoist` is
improper. Now rename it to `onFocusChanged`, and it helps any victim
when reading source code of TabsSession.