### PR TITLE
[TabTray] Switch to next tab after deleting the old focused one

### DIFF
--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayContract.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayContract.java
@@ -29,7 +29,7 @@ class TabTrayContract {
 
         int getCurrentTabPosition();
 
-        void switchTab(int tabPosition, Runnable finishCallback);
+        void switchTab(int tabPosition);
         void removeTab(int tabPosition);
     }
 }

--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayFragment.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayFragment.java
@@ -140,6 +140,7 @@ public class TabTrayFragment extends DialogFragment implements TabTrayContract.V
     public void onStop() {
         super.onStop();
         tabsSession.removeTabsViewListener(onTabModelChangedListener);
+        tabsSession.removeTabsChromeListener(onTabModelChangedListener);
     }
 
     @Nullable
@@ -209,7 +210,7 @@ public class TabTrayFragment extends DialogFragment implements TabTrayContract.V
 
         if (tabs.isEmpty()) {
             notifyFragmentListener(FragmentListener.TYPE.SHOW_HOME, false);
-            uiHandler.post(dismissRunnable);
+            postOnNextFrame(dismissRunnable);
         }
     }
 
@@ -226,7 +227,7 @@ public class TabTrayFragment extends DialogFragment implements TabTrayContract.V
 
     @Override
     public void tabSwitched(int tabPosition) {
-        uiHandler.post(dismissRunnable);
+        postOnNextFrame(dismissRunnable);
     }
 
     @Override
@@ -412,7 +413,7 @@ public class TabTrayFragment extends DialogFragment implements TabTrayContract.V
 
     private void onNewTabClicked() {
         notifyFragmentListener(FragmentListener.TYPE.SHOW_HOME, false);
-        uiHandler.post(dismissRunnable);
+        postOnNextFrame(dismissRunnable);
     }
 
     private void initWindowBackground(Context context) {
@@ -511,6 +512,15 @@ public class TabTrayFragment extends DialogFragment implements TabTrayContract.V
             // tray is fully expanded (slideOffset >= 1). See prepareExpandAnimation()
             logoMan.setVisibility(View.VISIBLE);
         }
+    }
+
+    private void postOnNextFrame(final Runnable runnable) {
+        uiHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                uiHandler.post(runnable);
+            }
+        });
     }
 
     private static class SlideAnimationCoordinator {
@@ -646,7 +656,7 @@ public class TabTrayFragment extends DialogFragment implements TabTrayContract.V
         }
 
         @Override
-        public void onTabHoist(@NonNull Tab tab, @Factor int factor) {
+        public void onTabHoist(@Nullable Tab tab, @Factor int factor) {
         }
 
         @Override

--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayPresenter.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayPresenter.java
@@ -28,17 +28,8 @@ public class TabTrayPresenter implements TabTrayContract.Presenter {
 
     @Override
     public void tabClicked(final int tabPosition) {
-        if (model.getCurrentTabPosition() != tabPosition) {
-            model.switchTab(tabPosition, new Runnable() {
-                @Override
-                public void run() {
-                    view.tabSwitched(tabPosition);
-                }
-            });
-
-        } else {
-            view.tabSwitched(tabPosition);
-        }
+        model.switchTab(tabPosition);
+        view.tabSwitched(tabPosition);
     }
 
     @Override
@@ -56,7 +47,7 @@ public class TabTrayPresenter implements TabTrayContract.Presenter {
         view.updateData(newTabs);
 
         if (!newTabs.isEmpty()) {
-            model.switchTab(newFocusTab, null);
+            model.switchTab(newFocusTab);
         }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayPresenter.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayPresenter.java
@@ -54,5 +54,9 @@ public class TabTrayPresenter implements TabTrayContract.Presenter {
 
         view.tabRemoved(tabPosition, oldFocusPos, newTabs.indexOf(oldFocusTab), newFocusTab);
         view.updateData(newTabs);
+
+        if (!newTabs.isEmpty()) {
+            model.switchTab(newFocusTab, null);
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabsSessionModel.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabsSessionModel.java
@@ -5,20 +5,10 @@
 
 package org.mozilla.focus.tabs.tabtray;
 
-import android.graphics.Bitmap;
-import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.view.View;
-import android.webkit.GeolocationPermissions;
-import android.webkit.ValueCallback;
-import android.webkit.WebChromeClient;
-import android.webkit.WebView;
 
 import org.mozilla.focus.BuildConfig;
 import org.mozilla.focus.tabs.Tab;
-import org.mozilla.focus.tabs.TabView;
-import org.mozilla.focus.tabs.TabsChromeListener;
 import org.mozilla.focus.tabs.TabsSession;
 
 import java.util.List;
@@ -42,7 +32,7 @@ class TabsSessionModel implements TabTrayContract.Model {
     }
 
     @Override
-    public void switchTab(int tabIdx, @Nullable final Runnable finishCallback) {
+    public void switchTab(int tabIdx) {
         final List<Tab> tabs = tabsSession.getTabs();
         if (tabIdx < 0 || tabIdx >= tabs.size()) {
             if (BuildConfig.DEBUG) {
@@ -51,19 +41,6 @@ class TabsSessionModel implements TabTrayContract.Model {
             return;
         }
 
-        // TODO: Any better approach?
-        // TabsSession#switchToTab() will implicitly post a call to TabsChromeListener#onTabHoist().
-        // By monitoring onTabHoist(), we can make sure finishCallback is run in the same frame loop
-        // with the others onTabHoist()
-        tabsSession.addTabsChromeListener(new TabsChromeAdapter() {
-            @Override
-            public void onTabHoist(@NonNull Tab tab, @Factor int factor) {
-                tabsSession.removeTabsChromeListener(this);
-                if (finishCallback != null) {
-                    finishCallback.run();
-                }
-            }
-        });
         tabsSession.switchToTab(tabs.get(tabIdx).getId());
     }
 
@@ -71,49 +48,5 @@ class TabsSessionModel implements TabTrayContract.Model {
     public void removeTab(int tabPosition) {
         final List<Tab> tabs = tabsSession.getTabs();
         tabsSession.dropTab(tabs.get(tabPosition).getId());
-    }
-
-    private static class TabsChromeAdapter implements TabsChromeListener {
-
-        @Override
-        public void onProgressChanged(@NonNull Tab tab, int progress) {
-        }
-
-        @Override
-        public void onReceivedTitle(@NonNull Tab tab, String title) {
-        }
-
-        @Override
-        public void onReceivedIcon(@NonNull Tab tab, Bitmap icon) {
-        }
-
-        @Override
-        public void onTabHoist(@NonNull Tab tab, @Factor int factor) {
-        }
-
-        @Override
-        public void onTabCountChanged(int count) {
-        }
-
-        @Override
-        public void onLongPress(@NonNull Tab tab, TabView.HitTarget hitTarget) {
-        }
-
-        @Override
-        public void onEnterFullScreen(@NonNull Tab tab, @NonNull TabView.FullscreenCallback callback, @Nullable View fullscreenContent) {
-        }
-
-        @Override
-        public void onExitFullScreen(@NonNull Tab tab) {
-        }
-
-        @Override
-        public boolean onShowFileChooser(@NonNull Tab tab, WebView webView, ValueCallback<Uri[]> filePathCallback, WebChromeClient.FileChooserParams fileChooserParams) {
-            return false;
-        }
-
-        @Override
-        public void onGeolocationPermissionsShowPrompt(@NonNull Tab tab, String origin, GeolocationPermissions.Callback callback) {
-        }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabsSessionModel.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabsSessionModel.java
@@ -42,7 +42,7 @@ class TabsSessionModel implements TabTrayContract.Model {
     }
 
     @Override
-    public void switchTab(int tabIdx, final Runnable finishCallback) {
+    public void switchTab(int tabIdx, @Nullable final Runnable finishCallback) {
         final List<Tab> tabs = tabsSession.getTabs();
         if (tabIdx < 0 || tabIdx >= tabs.size()) {
             if (BuildConfig.DEBUG) {
@@ -59,7 +59,9 @@ class TabsSessionModel implements TabTrayContract.Model {
             @Override
             public void onTabHoist(@NonNull Tab tab, @Factor int factor) {
                 tabsSession.removeTabsChromeListener(this);
-                finishCallback.run();
+                if (finishCallback != null) {
+                    finishCallback.run();
+                }
             }
         });
         tabsSession.switchToTab(tabs.get(tabIdx).getId());


### PR DESCRIPTION
Since the new TabsSession#dropTab() will not call TabsSession#hoistTab(), we have to switch to the next focused tab explicitly