### PR TITLE
refactor: make tests in disklrucache works again.

### DIFF
--- a/third_party/glide/disklrucache/build.gradle
+++ b/third_party/glide/disklrucache/build.gradle
@@ -1,5 +1,30 @@
 apply plugin: 'java'
-
+apply plugin: 'checkstyle'
 
 targetCompatibility = '1.7'
 sourceCompatibility = '1.7'
+
+
+repositories {
+    jcenter()
+}
+
+checkstyle {
+    toolVersion = "6.6"
+}
+
+checkstyle {
+    configFile = new File(projectDir, 'checkstyle.xml')
+}
+
+dependencies {
+    def junitVersion = hasProperty('JUNIT_VERSION') ? JUNIT_VERSION : '4.11';
+    testCompile "junit:junit:${junitVersion}"
+    testCompile 'commons-io:commons-io:2.1'
+    testCompile 'org.easytesting:fest-assert-core:2.0M10'
+}
+
+def uploaderScript = "${rootProject.projectDir}/scripts/upload.gradle"
+if (file(uploaderScript).exists()) {
+    apply from: uploaderScript
+}


### PR DESCRIPTION
unit tests in disklrucache module will fail cause we can't find the dependencies. This patch is to bring them back