### PR TITLE
add2home: Rise threshold for shortcut icon #56

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/FavIconUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/FavIconUtils.java
@@ -22,6 +22,8 @@ import org.mozilla.focus.R;
  */
 
 public class FavIconUtils {
+
+
     public static Bitmap getRefinedBitmap(Resources res, Bitmap source, char initial) {
         if (source.getWidth() > res.getDimensionPixelSize(R.dimen.favicon_downscale_threshold_size)) {
             int targetSize = res.getDimensionPixelSize(R.dimen.favicon_target_size);
@@ -179,4 +181,18 @@ public class FavIconUtils {
 
         return snippet;
     }
+
+    static Bitmap getRefinedShortcutIcon(Resources res, Bitmap source, char initial) {
+        final int sizeThreshold = res.getDimensionPixelSize(R.dimen.shortcut_icon_size);
+
+        if (source == null || source.getWidth() < sizeThreshold) {
+            return getInitialBitmap(res, source, initial);
+        }
+        if (source.getWidth() > sizeThreshold) {
+            return Bitmap.createScaledBitmap(source, sizeThreshold, sizeThreshold, false);
+        } else {
+            return source;
+        }
+    }
+
 }

--- a/app/src/main/java/org/mozilla/focus/utils/ShortcutUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/ShortcutUtils.java
@@ -39,7 +39,7 @@ public class ShortcutUtils {
             // if favicon is not ready, we use the default initial icon with white color
             icon = FavIconUtils.getInitialBitmap(resources, null, representativeCharacter);
         } else {
-            icon = FavIconUtils.getRefinedBitmap(resources, bitmap, representativeCharacter);
+            icon = FavIconUtils.getRefinedShortcutIcon(resources, bitmap, representativeCharacter);
         }
         // label must not be empty
         String label = title;

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -36,6 +36,8 @@
     <dimen name="favicon_downscale_threshold_size">128px</dimen>
     <dimen name="favicon_target_size">100px</dimen>
 
+    <dimen name="shortcut_icon_size">48dp</dimen>
+
     <dimen name="home_padding_url_bar_to_title">60dp</dimen>
     <dimen name="home_padding_url_bar_to_top_sites">36dp</dimen>
 


### PR DESCRIPTION
Previously we use favicon as shortcut icon. It's too small so I rise threshold for shortcut icon here. 