### PR TITLE
Fix crash in RelocateService start not in foreground after sdk26

### DIFF
--- a/app/src/main/java/org/mozilla/focus/notification/NotificationId.java
+++ b/app/src/main/java/org/mozilla/focus/notification/NotificationId.java
@@ -9,4 +9,5 @@ public class NotificationId {
     public static final int SURVEY_ON_3RD_LAUNCH = 1000;
     public static final int LOVE_FIREFOX = 1001;
     public static final int DEFAULT_BROWSER = 1002;
+    public static final int RELOCATE_SERVICE = 2000;
 }


### PR DESCRIPTION
This patch does the minimum requirement not to crash after upgrade target SDK to 26.
However, Jack suggests we do another change on the notification flow.

The expected result is,
1. User starts the download and system DownloadManager prompt a notification for progress update.
2. On download completed, NO notification if we're going to move the file to SD card; SHOW notification otherwise.
3. Show a notification to indicate user that the file is moving to the SD card.(startForegroun)
4. Show download complete notification after file moving completed.

Closes #1484 
