### PR TITLE
Fix crash in RelocateService start not in foreground after sdk26

### DIFF
--- a/app/src/main/java/org/mozilla/focus/notification/NotificationId.java
+++ b/app/src/main/java/org/mozilla/focus/notification/NotificationId.java
@@ -9,4 +9,5 @@ public class NotificationId {
     public static final int SURVEY_ON_3RD_LAUNCH = 1000;
     public static final int LOVE_FIREFOX = 1001;
     public static final int DEFAULT_BROWSER = 1002;
+    public static final int RELOCATE_SERVICE = 2000;
 }


### PR DESCRIPTION
Closes #1484