### PR TITLE
bug: detach webview if BrowserFragment is convered by HomeFragment

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/BrowserMediator.java
+++ b/app/src/main/java/org/mozilla/focus/activity/BrowserMediator.java
@@ -38,6 +38,15 @@ class BrowserMediator {
         raiseBrowserScreen(false);
     }
 
+    void setInForeground(final boolean isForeground) {
+        final FragmentManager fragmentManager = this.activity.getSupportFragmentManager();
+        final BrowserFragment fragment = findBrowserFragment(fragmentManager);
+        if (isForeground) {
+            fragment.goForeground();
+        } else {
+            fragment.goBackground();
+        }
+    }
 
     private BrowserFragment findBrowserFragment(FragmentManager fm) {
         return (BrowserFragment) fm.findFragmentById(R.id.browser);

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -24,6 +24,7 @@ import android.support.design.widget.BottomSheetDialog;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.content.LocalBroadcastManager;
@@ -115,6 +116,8 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
 
         mainMediator = new MainMediator(this);
         screenNavigator = new ScreenNavigator(this);
+
+        getSupportFragmentManager().addOnBackStackChangedListener(new BackStackListener());
 
         SafeIntent intent = new SafeIntent(getIntent());
 
@@ -904,6 +907,19 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
             // TabView and View is totally different, we know WebViewProvider returns a TabView for now,
             // but there is no promise about this.
             return (TabView) WebViewProvider.create(this.activity, null);
+        }
+    }
+
+    private class BackStackListener implements FragmentManager.OnBackStackChangedListener {
+        @Override
+        public void onBackStackChanged() {
+            final BrowserFragment fragment = getBrowserFragment();
+            final Fragment top = MainActivity.this.mainMediator.getTopFragment();
+            if (top == null) {
+                fragment.goForeground();
+            } else {
+                fragment.goBackground();
+            }
         }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/activity/ScreenNavigator.java
+++ b/app/src/main/java/org/mozilla/focus/activity/ScreenNavigator.java
@@ -54,6 +54,7 @@ public class ScreenNavigator {
         logMethod();
 
         this.browserMediator.raiseBrowserScreen(animate);
+        this.browserMediator.setInForeground(true);
     }
 
     /**
@@ -88,6 +89,7 @@ public class ScreenNavigator {
 
         this.mainMediator.clearAllFragment(false);
         this.mainMediator.showHomeScreen(animate, true);
+        this.browserMediator.setInForeground(false);
     }
 
     /**

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -445,6 +445,23 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         permissionHandler.tryAction(this, Manifest.permission.WRITE_EXTERNAL_STORAGE, ACTION_CAPTURE, null);
     }
 
+    public void goBackground() {
+        final Tab current = tabsSession.getFocusTab();
+        if (current != null && current.getTabView() != null) {
+            current.detach();
+            webViewSlot.removeView(current.getTabView().getView());
+        }
+    }
+
+    public void goForeground() {
+        final Tab current = tabsSession.getFocusTab();
+        if (webViewSlot.getChildCount() == 0 && current != null && current.getTabView() != null) {
+            final View inView = current.getTabView().getView();
+            webViewSlot.addView(inView);
+
+        }
+    }
+
     private void initialiseNormalBrowserUi() {
         urlView.setOnClickListener(this);
     }


### PR DESCRIPTION
Per specification, if user press '+' to hoist HomeFragment, we should
pause video playback from BrowserFragment. We could achieve this by
detaching webview.

to fix #1586