### PR TITLE
ci: Raise APK size limit to 2.56 MB. Fix #1752

### DIFF
--- a/tools/metrics/apk_size.py
+++ b/tools/metrics/apk_size.py
@@ -8,7 +8,7 @@ from os import path, listdir, stat
 from sys import exit
 import argparse
 
-SIZE_LIMIT = 2.5 * 1024 * 1024 
+SIZE_LIMIT = 2.56 * 1024 * 1024 
 parser = argparse.ArgumentParser(description='Determine Path')
 parser.add_argument('product', choices=['focus', 'preview'], default='focus')
 parser.add_argument('engine', choices=['webkit'], default='webkit')


### PR DESCRIPTION
Fix #1752
Adding Firebase will slightly increase the APK size from 2374676B (2.26xx MB) to 2665941B (2.54xx MB). See #1084