### PR TITLE
Fix 'Untagged socket detected' crash right after try to download a file

### DIFF
--- a/app/src/main/java/org/mozilla/focus/download/GetImgHeaderTask.java
+++ b/app/src/main/java/org/mozilla/focus/download/GetImgHeaderTask.java
@@ -1,6 +1,9 @@
 package org.mozilla.focus.download;
 
+import android.net.TrafficStats;
 import android.os.AsyncTask;
+
+import org.mozilla.focus.network.SocketTags;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -24,6 +27,7 @@ public class GetImgHeaderTask extends AsyncTask<String, Void, String> {
 
     @Override
     protected String doInBackground(String... params) {
+        TrafficStats.setThreadStatsTag(SocketTags.DOWNLOADS);
         HttpURLConnection connection = null;
         String contentType = "";
         int responseCode = 0;

--- a/app/src/main/java/org/mozilla/focus/network/SocketTags.java
+++ b/app/src/main/java/org/mozilla/focus/network/SocketTags.java
@@ -2,4 +2,5 @@ package org.mozilla.focus.network;
 
 public class SocketTags {
     public static final int SEARCH_SUGGESTION = 10000;
+    public static final int DOWNLOADS = 10001;
 }


### PR DESCRIPTION
04-03 17:45:55.245 23205-24059/? E/StrictMode: null
    java.lang.Throwable: Untagged socket detected; use TrafficStats.setThreadSocketTag() to track all network usage
        at android.os.StrictMode.onUntaggedSocket(StrictMode.java:2012)
        at com.android.server.NetworkManagementSocketTagger.tag(NetworkManagementSocketTagger.java:78)
        at libcore.io.BlockGuardOs.tagSocket(BlockGuardOs.java:47)
        at libcore.io.BlockGuardOs.socket(BlockGuardOs.java:310)
        at libcore.io.IoBridge.socket(IoBridge.java:667)
        at java.net.PlainSocketImpl.socketCreate(PlainSocketImpl.java:116)
        at java.net.AbstractPlainSocketImpl.create(AbstractPlainSocketImpl.java:98)
        at java.net.Socket.createImpl(Socket.java:484)
        at java.net.Socket.getImpl(Socket.java:547)
        at java.net.Socket.setSoTimeout(Socket.java:1175)
        at com.android.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:139)
        at com.android.okhttp.internal.io.RealConnection.connect(RealConnection.java:112)
        at com.android.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:184)
        at com.android.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
        at com.android.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
        at com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
        at com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
        at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:461)
        at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:407)
        at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getHeaders(HttpURLConnectionImpl.java:163)
        at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getHeaderField(HttpURLConnectionImpl.java:207)
        at java.net.URLConnection.getContentType(URLConnection.java:509)
        at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getContentType(DelegatingHttpsURLConnection.java:150)
        at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getContentType(Unknown Source:0)
        at org.mozilla.focus.download.GetImgHeaderTask.doInBackground(GetImgHeaderTask.java:34)
        at org.mozilla.focus.download.GetImgHeaderTask.doInBackground(GetImgHeaderTask.java:13)
        at android.os.AsyncTask$2.call(AsyncTask.java:333)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:245)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
        at java.lang.Thread.run(Thread.java:764)