### PR TITLE
Show smile face ':)' on tab counter before the tabs are restored

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -72,6 +72,7 @@ import org.mozilla.focus.utils.UrlUtils;
 import org.mozilla.focus.web.BrowsingSession;
 import org.mozilla.focus.web.WebViewProvider;
 import org.mozilla.focus.widget.FragmentListener;
+import org.mozilla.focus.widget.TabRestoreMonitor;
 
 import java.io.File;
 import java.util.List;
@@ -80,7 +81,7 @@ import java.util.Locale;
 public class MainActivity extends LocaleAwareAppCompatActivity implements FragmentListener,
         SharedPreferences.OnSharedPreferenceChangeListener,
         TabsSessionProvider.SessionHost, TabModelStore.AsyncQueryListener,
-        ScreenNavigator.Provider {
+        TabRestoreMonitor, ScreenNavigator.Provider {
 
     public static final String EXTRA_TEXT_SELECTION = "text_selection";
 
@@ -875,6 +876,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
         return tabsSession;
     }
 
+    @Override
     public boolean isTabRestoredComplete() {
         return isTabRestoredComplete;
     }

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -104,6 +104,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
     private static boolean sIsNewCreated = true;
 
     private TabsSession tabsSession;
+    private boolean isTabRestoredComplete = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -874,8 +875,13 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
         return tabsSession;
     }
 
+    public boolean isTabRestoredComplete() {
+        return isTabRestoredComplete;
+    }
+
     @Override
     public void onQueryComplete(List<TabModel> tabModelList, String currentTabId) {
+        isTabRestoredComplete = true;
         getTabsSession().restoreTabs(tabModelList, currentTabId);
         Tab currentTab = getTabsSession().getFocusTab();
         if (currentTab != null && safeForFragmentTransactions) {
@@ -884,10 +890,15 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
     }
 
     private void restoreTabsFromPersistence() {
+        isTabRestoredComplete = false;
         TabModelStore.getInstance(this).getSavedTabs(this, this);
     }
 
     private void saveTabsToPersistence() {
+        if (!isTabRestoredComplete) {
+            return;
+        }
+
         List<TabModel> tabModelListForPersistence = getTabsSession().getTabModelListForPersistence();
         final String currentTabId = (getTabsSession().getFocusTab() != null)
                 ? getTabsSession().getFocusTab().getId()

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -58,6 +58,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import org.mozilla.focus.R;
+import org.mozilla.focus.activity.MainActivity;
 import org.mozilla.focus.activity.ScreenNavigator;
 import org.mozilla.focus.download.DownloadInfo;
 import org.mozilla.focus.download.DownloadInfoManager;
@@ -409,7 +410,7 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         tabsSession.addTabsChromeListener(this.tabsContentListener);
         tabsSession.setDownloadCallback(downloadCallback);
 
-        if (tabCounter != null) {
+        if (tabCounter != null && isTabRestoredComplete()) {
             tabCounter.setCount(tabsSession.getTabsCount());
         }
 
@@ -1050,6 +1051,11 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         return ScreenNavigator.get(getContext()).isBrowserInForeground();
     }
 
+    private boolean isTabRestoredComplete() {
+        return (getActivity() instanceof MainActivity)
+                && ((MainActivity) getActivity()).isTabRestoredComplete();
+    }
+
     class TabsContentListener implements TabsViewListener, TabsChromeListener {
         private HistoryInserter historyInserter = new HistoryInserter();
 
@@ -1135,7 +1141,9 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
 
         @Override
         public void onTabCountChanged(int count) {
-            tabCounter.setCountWithAnimation(count);
+            if (isTabRestoredComplete()) {
+                tabCounter.setCountWithAnimation(count);
+            }
         }
 
         @Override

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -58,7 +58,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import org.mozilla.focus.R;
-import org.mozilla.focus.activity.MainActivity;
 import org.mozilla.focus.activity.ScreenNavigator;
 import org.mozilla.focus.download.DownloadInfo;
 import org.mozilla.focus.download.DownloadInfoManager;
@@ -91,6 +90,7 @@ import org.mozilla.focus.web.Download;
 import org.mozilla.focus.widget.AnimatedProgressBar;
 import org.mozilla.focus.widget.BackKeyHandleable;
 import org.mozilla.focus.widget.FragmentListener;
+import org.mozilla.focus.widget.TabRestoreMonitor;
 
 import java.lang.ref.WeakReference;
 import java.util.List;
@@ -1052,8 +1052,14 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
     }
 
     private boolean isTabRestoredComplete() {
-        return (getActivity() instanceof MainActivity)
-                && ((MainActivity) getActivity()).isTabRestoredComplete();
+        if (!(getActivity() instanceof TabRestoreMonitor)) {
+            if (AppConstants.isDevBuild()) {
+                throw new RuntimeException("Base activity needs to implement TabRestoreMonitor");
+            } else {
+                return true; // No clue for the tab restore status. Just return true to bypass smile face tab counter
+            }
+        }
+        return ((TabRestoreMonitor) getActivity()).isTabRestoredComplete();
     }
 
     class TabsContentListener implements TabsViewListener, TabsChromeListener {

--- a/app/src/main/java/org/mozilla/focus/tabs/TabCounter.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/TabCounter.java
@@ -31,8 +31,9 @@ public class TabCounter extends RelativeLayout {
     private int count;
     private float currentTextRatio;
 
-    public static final int MAX_VISIBLE_TABS = 99;
-    public static final String SO_MANY_TABS_OPEN = "∞";
+    private static final int MAX_VISIBLE_TABS = 99;
+    private static final String SO_MANY_TABS_OPEN = "∞";
+    private static final String DEFAULT_TABS_COUNTER_TEXT = ":)";
 
     private static final float ONE_DIGIT_SIZE_RATIO = 0.6f;
     private static final float TWO_DIGITS_SIZE_RATIO = 0.5f;
@@ -59,6 +60,10 @@ public class TabCounter extends RelativeLayout {
         box = findViewById(R.id.counter_box);
         bar = findViewById(R.id.counter_bar);
         text = findViewById(R.id.counter_text);
+        text.setText(DEFAULT_TABS_COUNTER_TEXT);
+        final int shiftOneDpForDefaultText = (int) TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP, 1, context.getResources().getDisplayMetrics());
+        text.setPadding(0, 0, 0, shiftOneDpForDefaultText);
 
         if (menuIconColor != defaultMenuIconColor) {
             tintDrawables(menuIconColor);
@@ -90,6 +95,7 @@ public class TabCounter extends RelativeLayout {
 
         adjustTextSize(count);
 
+        text.setPadding(0, 0, 0, 0);
         text.setText(formatForDisplay(count));
         this.count = count;
 
@@ -104,6 +110,7 @@ public class TabCounter extends RelativeLayout {
     public void setCount(int count) {
         adjustTextSize(count);
 
+        text.setPadding(0, 0, 0, 0);
         text.setText(formatForDisplay(count));
         this.count = count;
     }

--- a/app/src/main/java/org/mozilla/focus/widget/TabRestoreMonitor.java
+++ b/app/src/main/java/org/mozilla/focus/widget/TabRestoreMonitor.java
@@ -1,0 +1,7 @@
+package org.mozilla.focus.widget;
+
+public interface TabRestoreMonitor {
+
+    boolean isTabRestoredComplete();
+
+}


### PR DESCRIPTION
Already reviewed by the designers. Close #1699 

![rocket-smile-tab-counter-shift-one-dp](https://user-images.githubusercontent.com/7045016/38549414-8c1d5bca-3ce6-11e8-9359-a5b11520dc84.png)
