### PR TITLE
[TabTray] Workaround to avoid crash when closing a tab

### DIFF
--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayPresenter.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayPresenter.java
@@ -33,6 +33,11 @@ public class TabTrayPresenter implements TabTrayContract.Presenter {
 
     @Override
     public void tabClicked(final int tabPosition) {
+        List<Tab> tabs = model.getTabs();
+        if (tabPosition < 0 || tabPosition >= tabs.size()) {
+            view.closeTabTray();
+            return;
+        }
         model.switchTab(tabPosition);
         view.tabSwitched(tabPosition);
     }

--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabsSessionModel.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabsSessionModel.java
@@ -32,21 +32,28 @@ class TabsSessionModel implements TabTrayContract.Model {
     }
 
     @Override
-    public void switchTab(int tabIdx) {
+    public void switchTab(int tabPosition) {
         final List<Tab> tabs = tabsSession.getTabs();
-        if (tabIdx < 0 || tabIdx >= tabs.size()) {
+        if (tabPosition < 0 || tabPosition >= tabs.size()) {
             if (BuildConfig.DEBUG) {
-                throw new ArrayIndexOutOfBoundsException("index: " + tabIdx + ", size: " + tabs.size());
+                throw new ArrayIndexOutOfBoundsException("index: " + tabPosition + ", size: " + tabs.size());
             }
             return;
         }
 
-        tabsSession.switchToTab(tabs.get(tabIdx).getId());
+        tabsSession.switchToTab(tabs.get(tabPosition).getId());
     }
 
     @Override
     public void removeTab(int tabPosition) {
         final List<Tab> tabs = tabsSession.getTabs();
+        if (tabPosition < 0 || tabPosition >= tabs.size()) {
+            if (BuildConfig.DEBUG) {
+                throw new ArrayIndexOutOfBoundsException("index: " + tabPosition + ", size: " + tabs.size());
+            }
+            return;
+        }
+
         tabsSession.dropTab(tabs.get(tabPosition).getId());
     }
 }


### PR DESCRIPTION
This workaround solution will not sync tab tray UI with tab data, i.e. The closed tab will still be visible on tab tray.

Result behavior:
Click the closed item => close tab tray, and show the previous page.
Dismiss the closed item => remove the item, and switch to the next focused page.
