### PR TITLE
Wrong boundary check for the font size ratio of tab counter(99)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/tabs/TabCounter.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/TabCounter.java
@@ -233,7 +233,7 @@ public class TabCounter extends RelativeLayout {
     }
 
     private void adjustTextSize(int newCount) {
-        final float newRatio = (newCount < MAX_VISIBLE_TABS && newCount >= 10) ? TWO_DIGITS_SIZE_RATIO : ONE_DIGIT_SIZE_RATIO;
+        final float newRatio = (newCount <= MAX_VISIBLE_TABS && newCount >= 10) ? TWO_DIGITS_SIZE_RATIO : ONE_DIGIT_SIZE_RATIO;
 
         if (newRatio != currentTextRatio) {
             currentTextRatio = newRatio;


### PR DESCRIPTION
Close #1793.

before:
![device-2018-04-13-103733](https://user-images.githubusercontent.com/7045016/38714148-6a955138-3f07-11e8-9803-3d23966ed0dd.png)

after:
![device-2018-04-13-103647](https://user-images.githubusercontent.com/7045016/38714163-7fbc3b94-3f07-11e8-858d-82f2a8766e73.png)

