### PR TITLE
Remove android text resolver dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,18 +7,15 @@ apply plugin: 'jacoco'
 apply plugin: 'jacoco-android'
 apply plugin: 'pmd'
 apply plugin: 'checkstyle'
-apply plugin: 'com.icesmith.androidtextresolver'
 apply plugin: 'com.google.gms.oss.licenses.plugin'
 
 buildscript {
     repositories {
         maven {
-            url "https://plugins.gradle.org/m2/"
         }
     }
 
     dependencies {
-        classpath "gradle.plugin.android-text-resolver:buildSrc:1.1.0"
     }
 }
 

--- a/app/src/debug/res/values-in/strings.xml
+++ b/app/src/debug/res/values-in/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="text_selection_search_action">Cari di Firefox Rocket Dev</string>
+</resources>

--- a/app/src/debug/res/values-zh-rCN/strings.xml
+++ b/app/src/debug/res/values-zh-rCN/strings.xml
@@ -3,6 +3,5 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
-    <string name="app_name" translatable="false">Firefox Rocket Dev</string>
-
+  <string name="text_selection_search_action">在 Firefox Rocket Dev 中搜索</string>
 </resources>

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -3,6 +3,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
-    <string name="app_name" translatable="false">Firefox Rocket Nightly</string>
+    <string name="app_name" translatable="false">Firefox Rocket Dev</string>
 
+    <string name="text_selection_search_action">Search in Firefox Rocket Dev</string>
 </resources>

--- a/app/src/main/java/org/mozilla/focus/utils/DialogUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/DialogUtils.java
@@ -5,10 +5,13 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.content.res.ResourcesCompat;
 import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.activity.MainActivity;
@@ -43,6 +46,10 @@ public class DialogUtils {
         });
 
         View dialogView = LayoutInflater.from(context).inflate(R.layout.layout_rate_app_dialog, (ViewGroup) null);
+
+        final TextView textView = dialogView.findViewById(R.id.rate_app_dialog_textview_title);
+        textView.setText(context.getString(R.string.rate_app_dialog_text_title, context.getString(R.string.app_name)));
+
         dialogView.findViewById(R.id.dialog_rate_app_btn_close).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -105,6 +112,10 @@ public class DialogUtils {
         });
 
         View dialogView = LayoutInflater.from(context).inflate(R.layout.layout_share_app_dialog, (ViewGroup) null);
+
+        final TextView textView = dialogView.findViewById(R.id.share_app_dialog_textview_title);
+        textView.setText(context.getString(R.string.share_app_dialog_text_title, context.getString(R.string.app_name)));
+
         dialogView.findViewById(R.id.dialog_share_app_btn_close).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -120,7 +131,7 @@ public class DialogUtils {
                 Intent sendIntent = new Intent(Intent.ACTION_SEND);
                 sendIntent.setType("text/plain");
                 sendIntent.putExtra(Intent.EXTRA_SUBJECT, context.getString(R.string.app_name));
-                sendIntent.putExtra(Intent.EXTRA_TEXT, context.getString(R.string.share_app_promotion_text));
+                sendIntent.putExtra(Intent.EXTRA_TEXT, context.getString(R.string.share_app_promotion_text, context.getString(R.string.app_name), context.getString(R.string.share_app_google_play_url)));
                 context.startActivity(Intent.createChooser(sendIntent, null));
                 if (dialog != null) {
                     dialog.dismiss();

--- a/app/src/main/res/layout/layout_rate_app_dialog.xml
+++ b/app/src/main/res/layout/layout_rate_app_dialog.xml
@@ -30,6 +30,7 @@
     </RelativeLayout>
 
     <TextView
+        android:id="@+id/rate_app_dialog_textview_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="30dp"

--- a/app/src/main/res/layout/layout_share_app_dialog.xml
+++ b/app/src/main/res/layout/layout_share_app_dialog.xml
@@ -30,6 +30,7 @@
     </RelativeLayout>
 
     <TextView
+        android:id="@+id/share_app_dialog_textview_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="30dp"

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -10,7 +10,7 @@
   <string name="menu_give_feedback">Kirimkan masukan</string>
   <string name="menu_share_with_friends">Bagikan dengan teman</string>
   <string name="share_dialog_title">Bagikan via</string>
-  <string name="text_selection_search_action">Cari di {{app_name}}</string>
+  <string name="text_selection_search_action">Cari di Firefox Rocket</string>
   <string name="about_content_body">%1$s adalah sebuah peramban cepat dan ringan buatan Mozilla. Misi kami adalah untuk mendorong internet yang sehat dan terbuka.</string>
   <string name="about_link_learn_more">Pelajari lebih lanjut</string>
   <string name="about_link_support">Dukungan</string>
@@ -154,16 +154,16 @@
   <string name="message_deleted_screenshot">Tangkapan layar dihapus</string>
   <string name="message_cannot_find_screenshot">Tidak bisa menampilkan tangkapan layar</string>
   <string name="remove">Hapus</string>
-  <string name="rate_app_dialog_text_title">Suka {{app_name}}?</string>
+  <string name="rate_app_dialog_text_title">Suka %1$s ?</string>
   <string name="rate_app_dialog_text_content">Terima kasih telah memilih produk kami. Masukan Anda sangat penting bagi kami.</string>
   <string name="rate_app_dialog_btn_go_rate">Tentu, beri 5 bintang!</string>
   <string name="rate_app_notification_action_rate">BERI NILAI 5 BINTANG</string>
   <string name="rate_app_dialog_btn_feedback">Tidak, kirimkan masukan.</string>
   <string name="rate_app_notification_action_feedback">MASUKAN</string>
-  <string name="share_app_dialog_text_title">Bagikan {{app_name}} dengan teman!</string>
+  <string name="share_app_dialog_text_title">Bagikan %1$s dengan teman!</string>
   <string name="share_app_dialog_text_content">- Cepat dan ringan\n- Hemat data\n- Tangkapan layar yang canggih</string>
   <string name="share_app_dialog_btn_share">Bagikan</string>
-  <string name="share_app_promotion_text">Yuk, coba peramban cepat dan ringan dari Mozilla! {{app_name}} {{share_app_google_play_url}}</string>
+  <string name="share_app_promotion_text">Yuk, coba peramban cepat dan ringan dari Mozilla! %1$s %2$s</string>
   <string name="your_rights_content1">%1$s adalah perangkat lunak bebas dan sumber terbuka yang dibuat oleh Mozilla dan kontributor lainnya.</string>
   <string name="your_rights_content2"><![CDATA["%1$s tersedia untuk Anda di bawah persyaratan "<a xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" href="%2$s">Lisensi Publik Mozilla</a>" dan lisensi sumber terbuka lainnya."]]></string>
   <string name="your_rights_content3"><![CDATA["Anda tidak diberi izin atau lisensi apa pun atas merek dagang Mozilla Foundation atau pihak mana pun, termasuk nama atau logo Mozilla, Firefox, atau %1$s. Informasi lebih lanjut bisa ditemukan "<a xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" href="%2$s">di sini</a>.]]></string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -10,7 +10,7 @@
   <string name="menu_give_feedback">提供反馈</string>
   <string name="menu_share_with_friends">与朋友分享</string>
   <string name="share_dialog_title">分享</string>
-  <string name="text_selection_search_action">在 {{app_name}} 中搜索</string>
+  <string name="text_selection_search_action">在 Firefox Rocket 中搜索</string>
   <string name="about_content_body">%1$s 是由 Mozilla 出品的快速而轻量的浏览器。我们以营造健康、开放的互联网为己任。</string>
   <string name="about_link_learn_more">详细了解</string>
   <string name="about_link_support">技术支持</string>
@@ -153,16 +153,16 @@
   <string name="message_deleted_screenshot">截图已删除</string>
   <string name="message_cannot_find_screenshot">无法显示此截图</string>
   <string name="remove">移除</string>
-  <string name="rate_app_dialog_text_title">喜欢 {{app_name}} 吗？</string>
+  <string name="rate_app_dialog_text_title">喜欢 %1$s 吗？</string>
   <string name="rate_app_dialog_text_content">感谢您选择我们的产品。您的反馈有助于我们的改进。</string>
   <string name="rate_app_dialog_btn_go_rate">是的，5 星好评！</string>
   <string name="rate_app_notification_action_rate">5 星好评</string>
   <string name="rate_app_dialog_btn_feedback">不，发送反馈。</string>
   <string name="rate_app_notification_action_feedback">反馈</string>
-  <string name="share_app_dialog_text_title">与朋友分享 {{app_name}}！</string>
+  <string name="share_app_dialog_text_title">与朋友分享 %1$s！</string>
   <string name="share_app_dialog_text_content">- 快速且轻量级\n- 节约流量\n- 强大的截图功能</string>
   <string name="share_app_dialog_btn_share">分享</string>
-  <string name="share_app_promotion_text">嘿，来试试出自 Mozilla 的超快轻量级浏览器吧！{{app_name}} {{share_app_google_play_url}}</string>
+  <string name="share_app_promotion_text">嘿，来试试出自 Mozilla 的超快轻量级浏览器吧！ %1$s %2$s</string>
   <string name="your_rights_content1">%1$s 是由 Mozilla 和其他贡献者提供的自由且开源软件。</string>
   <string name="your_rights_content2"><![CDATA["%1$s 根据 "<a xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" href="%2$s">Mozilla &#20844;&#20849;&#35768;&#21487;&#35777;</a>以及其他开源许可证向您提供。]]></string>
   <string name="your_rights_content3"><![CDATA[您没有得到 Mozilla 基金会或任何其他方面（包括 Mozilla、Firefox 或 %1$s 的名称或标志）的商标授权。更多信息参见<a xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" href="%2$s">&#27492;&#22788;</a>。]]></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
 
     <!-- This is the label of an action we offer when the user selects text in other third-party apps.
          Clicking this action will launch Rocket and perform a search in the default search engine. -->
-    <string name="text_selection_search_action">Search in {{app_name}}</string>
+    <string name="text_selection_search_action">Search in Firefox Rocket</string>
 
     <!-- Content of about Rocket. Argument 1 is the major body of the content #about_content_body.
          Argument 2,4,6,8 is the urls.
@@ -313,7 +313,7 @@
     <string name="remove">Remove</string>
 
     <!--In-app Promotion, Rate the App-->
-    <string name="rate_app_dialog_text_title">Love {{app_name}}?</string>
+    <string name="rate_app_dialog_text_title">Love %1$s?</string>
     <string name="rate_app_dialog_text_content">Thank you for choosing our product. Your feedback is important to us.</string>
     <string name="rate_app_dialog_btn_go_rate">Yes, rate 5 stars!</string>
     <string name="rate_app_notification_action_rate">RATE 5 STARS</string>
@@ -323,11 +323,11 @@
     <string name="rate_app_feedback_url" translatable="false">https://qsurvey.mozilla.com/s3/Firefox-Rocket-Input/</string>
 
     <!--In-app Promotion, Share app-->
-    <string name="share_app_dialog_text_title">Share {{app_name}} with friends!</string>
+    <string name="share_app_dialog_text_title">Share %1$s with friends!</string>
     <string name="share_app_dialog_text_content">- Fast and lightweight\n- Data saving\n- Powerful screenshots</string>
     <string name="share_app_dialog_btn_share">Share</string>
     <string name="share_app_google_play_url" translatable="false">https://mzl.la/2kScptw</string>
-    <string name="share_app_promotion_text">Hey, check out this fast and lightweight browser from Mozilla. {{app_name}} {{share_app_google_play_url}}</string>
+    <string name="share_app_promotion_text">Hey, check out this fast and lightweight browser from Mozilla. %1$s %2$s</string>
 
     <!-- Text shown in the "Your rights" screen.
     %1$s will be replaced with the name of the app (e.g. Firefox Rocket)-->

--- a/app/src/preview/res/values-in/strings.xml
+++ b/app/src/preview/res/values-in/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="text_selection_search_action">Cari di Firefox Rocket Nightly</string>
+</resources>

--- a/app/src/preview/res/values-zh-rCN/strings.xml
+++ b/app/src/preview/res/values-zh-rCN/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="text_selection_search_action">在 Firefox Rocket Nightly 中搜索</string>
+</resources>

--- a/app/src/preview/res/values/strings.xml
+++ b/app/src/preview/res/values/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="app_name" translatable="false">Firefox Rocket Nightly</string>
+
+    <string name="text_selection_search_action">Search in Firefox Rocket Nightly</string>
+</resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-android.enableAapt2=false
+#android.enableAapt2=false


### PR DESCRIPTION
Android Text Resolver is a gradle plugin to allow us replace a string inside another string by placeholder, ex.```{{app_name}}```. The necessary use case is the string used in ```AndroidManifest.xml``` only allows plain text, not formatted text, ex. ```%1$s```. However, this plugin is broken after ```aapt2``` enabled with 3.1.0 android gradle plugin, and output the merged resource file into ```.flat``` binary format, cause the string not able to be resolved by the plugin.

Thus, this plugin is our SDK upgrade blocker.