### PR TITLE
Translation.md links to the wrong project

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -2,7 +2,7 @@
 
 ## Updating translations
 
-Firefox Rocket for Android is getting localized on [Pontoon](https://pontoon.mozilla.org/projects/focus-for-android/).
+Firefox Rocket for Android is getting localized on [Pontoon](https://pontoon.mozilla.org/projects/firefox-rocket/).
 
 For converting between Android XML files and Gettext PO files (to be consumed by Pontoon) we use a local, slightly modified version of [android2po](https://github.com/miracle2k/android2po) (See `tools/l10n/android2po`).
 


### PR DESCRIPTION
Link the translation project "Firefox Rocket" instead of "Focus for Android" in the docs.