### PR TITLE
defBrowser: only apply to devices under android M

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/DefaultBrowserPreference.java
+++ b/app/src/main/java/org/mozilla/focus/widget/DefaultBrowserPreference.java
@@ -91,8 +91,7 @@ public class DefaultBrowserPreference extends Preference {
 
     private void init() {
         if (action == null) {
-            action = ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
-                    || Build.MANUFACTURER.toLowerCase().contains("vivo"))
+            action = ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.M))
                     ? new DefaultAction(this)
                     : new LowSdkAction(this);
 


### PR DESCRIPTION
The special action to clear default brwoser will only be applied to
Android 5.x devices.