### PR TITLE
Closes #1943: Mock final class AppConstants (WIP)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -236,6 +236,8 @@ dependencies {
     testImplementation "org.robolectric:robolectric:${Versions.robolectric}"
     testImplementation "org.mockito:mockito-core:${Versions.mockito}"
 
+    testImplementation "org.powermock:powermock-mockito-release-full:${Versions.powermoch}"
+
     androidTestImplementation("com.android.support.test.espresso:espresso-core:${Versions.espresso}", {
         exclude group: 'com.android.support', module: 'support-annotations'
     })

--- a/app/src/test/java/org/mozilla/focus/autocomplete/UrlAutoCompleteFilterTest.java
+++ b/app/src/test/java/org/mozilla/focus/autocomplete/UrlAutoCompleteFilterTest.java
@@ -10,14 +10,13 @@ import org.junit.runner.RunWith;
 import org.mozilla.focus.widget.InlineAutocompleteEditText;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.powermock.api.mockito.PowerMockito.mock;
 
 @RunWith(RobolectricTestRunner.class)
 public class UrlAutoCompleteFilterTest {

--- a/app/src/test/java/org/mozilla/focus/telemetry/AppLaunchMethodTest.kt
+++ b/app/src/test/java/org/mozilla/focus/telemetry/AppLaunchMethodTest.kt
@@ -4,7 +4,7 @@ import android.content.Intent
 import org.junit.Assert
 import org.junit.Test
 import org.mockito.Mockito
-import org.mockito.Mockito.mock
+import org.powermock.api.mockito.PowerMockito.mock
 import org.mozilla.focus.utils.SafeIntent
 
 class AppLaunchMethodTest {

--- a/app/src/testWebkit/java/org/mozilla/focus/telemetry/FirebaseEventTest.java
+++ b/app/src/testWebkit/java/org/mozilla/focus/telemetry/FirebaseEventTest.java
@@ -8,14 +8,22 @@ package org.mozilla.focus.telemetry;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mozilla.focus.utils.AppConstants;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
 
 import static junit.framework.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({FirebaseEventTest.class, AppConstants.class})
 public class FirebaseEventTest {
 
     final private static char FAKE_EVENT_NAME_CHAR = 'a';
@@ -50,15 +58,23 @@ public class FirebaseEventTest {
         return new String(chars);
     }
 
+    @Before
+    public void warmUp() {
+
+        mockStatic(AppConstants.class);
+        when(AppConstants.isReleaseBuild()).thenReturn(false);
+
+    }
+
     @NonNull
     private FirebaseEvent generateValidFirebaseEvent() {
         return FirebaseEvent.create("", "", "", VALID_EVENT_NAME);
     }
 
-//    @Test(expected = IllegalArgumentException.class)
-//    public void eventNameLongerThan40Characters_shouldThrowIllegalArgumentException() {
-//        FirebaseEvent.create("", "", "", INVALID_EVENT_NAME);
-//    }
+    @Test(expected = IllegalArgumentException.class)
+    public void eventNameLongerThan40Characters_shouldThrowIllegalArgumentException() {
+        FirebaseEvent.create("", "", "", INVALID_EVENT_NAME);
+    }
 
     @Test
     public void eventNameValid_shouldBeSafe() {
@@ -69,7 +85,6 @@ public class FirebaseEventTest {
         }
     }
 
-
     @Test
     public void nullContext_shouldBeSafe() {
         try {
@@ -79,14 +94,14 @@ public class FirebaseEventTest {
         }
     }
 
-//    @Test(expected = IllegalArgumentException.class)
-//    public void paramSizeTooLarge_shouldThrow() {
-//        final FirebaseEvent firebaseEvent = generateValidFirebaseEvent();
-//        final Bundle params = mock(Bundle.class);
-//        firebaseEvent.setParam(params);
-//        when(params.size()).thenReturn(FirebaseEvent.MAX_PARAM_SIZE);
-//        firebaseEvent.param("", "");
-//    }
+    @Test(expected = IllegalArgumentException.class)
+    public void paramSizeTooLarge_shouldThrow() {
+        final FirebaseEvent firebaseEvent = generateValidFirebaseEvent();
+        final Bundle params = mock(Bundle.class);
+        firebaseEvent.setParam(params);
+        when(params.size()).thenReturn(FirebaseEvent.MAX_PARAM_SIZE);
+        firebaseEvent.param("", "");
+    }
 
     @Test
     public void paramSizeValid_shouldBeSafe() {
@@ -103,11 +118,11 @@ public class FirebaseEventTest {
         }
     }
 
-//    @Test(expected = IllegalArgumentException.class)
-//    public void paramKeyLengthTooLarge_shouldThrow() {
-//        final FirebaseEvent firebaseEvent = generateValidFirebaseEvent();
-//        firebaseEvent.param(INVALID_PARAM_NAME, "");
-//    }
+    @Test(expected = IllegalArgumentException.class)
+    public void paramKeyLengthTooLarge_shouldThrow() {
+        final FirebaseEvent firebaseEvent = generateValidFirebaseEvent();
+        firebaseEvent.param(INVALID_PARAM_NAME, "");
+    }
 
     @Test
     public void paramKeyValid_shouldBeSafe() {
@@ -119,11 +134,11 @@ public class FirebaseEventTest {
         }
     }
 
-//    @Test(expected = IllegalArgumentException.class)
-//    public void paramValueLengthTooLarge_shouldThrow() {
-//        final FirebaseEvent firebaseEvent = generateValidFirebaseEvent();
-//        firebaseEvent.param("", INVALID_PARAM_VALUE);
-//    }
+    @Test(expected = IllegalArgumentException.class)
+    public void paramValueLengthTooLarge_shouldThrow() {
+        final FirebaseEvent firebaseEvent = generateValidFirebaseEvent();
+        firebaseEvent.param("", INVALID_PARAM_VALUE);
+    }
 
     @Test
     public void paramValueLengthValid_shouldBeSafe() {

--- a/app/src/testWebkit/java/org/mozilla/focus/webkit/TrackingProtectionWebViewClientTest.java
+++ b/app/src/testWebkit/java/org/mozilla/focus/webkit/TrackingProtectionWebViewClientTest.java
@@ -23,7 +23,7 @@ import org.robolectric.annotation.Config;
 import java.util.Map;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.mockito.Mockito.when;
 
 // IMPORTANT NOTE - IF RUNNING TESTS USING ANDROID STUDIO:

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -20,6 +20,7 @@ object Versions {
     const val adjust = "4.11.4"
     const val junit = "4.12"
     const val mockito = "2.12.0"
+    const val powermoch = "1.6.1"
     const val robolectric = "3.5.1"
     const val espresso = "3.0.1"
     const val test_runner = "1.0.1"


### PR DESCRIPTION
Closes #1943 
Use PowerMock to mock static and final class.
After I change all Mockito.mock to PowerMock.mock, everything works.

I need to understand how they work and what's the difference before it's landed.

I've also found that we run unit test on release build on purpose.  (find 'testFocusWebkitReleaseUnitTest' in unit test step in 'release' workflow)