### PR TITLE
Use the value from Firebase, if disabled will return the default value

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/AppConfigWrapper.java
+++ b/app/src/main/java/org/mozilla/focus/utils/AppConfigWrapper.java
@@ -24,7 +24,7 @@ public class AppConfigWrapper {
                     getRateAppNotificationLaunchTimeThreshold(context) -
                     getRateDialogLaunchTimeThreshold(context);
         }
-        return DialogUtils.APP_CREATE_THRESHOLD_FOR_SHARE_DIALOG;
+        return FirebaseHelper.getRcLong(context, FirebaseHelper.SHARE_APP_DIALOG_THRESHOLD);
     }
 
     public static long getRateDialogLaunchTimeThreshold(Context context) {


### PR DESCRIPTION
I found a bug that getShareDialogLaunchTimeThreshold will not use the value from Firebase Remote Config. This PR fixed that.