### PR TITLE
Fix ‘Duplicate finish request for ActivityRecord’ warning issue.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/BrowsingHistoryTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/BrowsingHistoryTest.java
@@ -88,7 +88,6 @@ public class BrowsingHistoryTest {
 
     @After
     public void tearDown() {
-        activityTestRule.getActivity().finishAndRemoveTask();
         // We unregister loadingIdlingResource here so other tests will not be affected.
         if (loadingIdlingResource != null) {
             IdlingRegistry.getInstance().unregister(loadingIdlingResource);

--- a/app/src/androidTest/java/org/mozilla/focus/activity/BrowsingIntentTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/BrowsingIntentTest.java
@@ -57,7 +57,6 @@ public class BrowsingIntentTest {
         if (loadingIdlingResource != null) {
             IdlingRegistry.getInstance().unregister(loadingIdlingResource);
         }
-        activityTestRule.getActivity().finishAndRemoveTask();
     }
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/focus/activity/DownloadTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/DownloadTest.java
@@ -67,7 +67,6 @@ public class DownloadTest {
     @After
     public void tearDown() throws Exception {
         clearDownloadFolder();
-        activityRule.getActivity().finishAndRemoveTask();
     }
 
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/GrantStoragePermissionTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/GrantStoragePermissionTest.java
@@ -115,7 +115,6 @@ public class GrantStoragePermissionTest {
         if (sessionLoadedIdlingResource != null) {
             IdlingRegistry.getInstance().unregister(sessionLoadedIdlingResource);
         }
-        activityRule.getActivity().finishAndRemoveTask();
     }
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/focus/activity/HomeTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/HomeTest.java
@@ -15,7 +15,6 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.json.JSONArray;
 import org.json.JSONException;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,12 +51,6 @@ public class HomeTest {
     public void setUp() {
         // Set the share preferences and start the activity
         AndroidTestUtils.beforeTest();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        // Remove activity from Recent Apps
-        activityRule.getActivity().finishAndRemoveTask();
     }
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/focus/activity/NavigationTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/NavigationTest.java
@@ -48,11 +48,6 @@ public class NavigationTest {
         activityTestRule.launchActivity(new Intent());
     }
 
-    @After
-    public void tearDown() {
-        activityTestRule.getActivity().finishAndRemoveTask();
-    }
-
     @Test
     public void browsingWebsiteBackAndForward_backAndFrowardToWebsite() {
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/RemoveTopSitesTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/RemoveTopSitesTest.java
@@ -64,11 +64,6 @@ public class RemoveTopSitesTest {
         activityTestRule.launchActivity(new Intent());
     }
 
-    @After
-    public void tearDown() {
-        activityTestRule.getActivity().finishAndRemoveTask();
-    }
-
     @Test
     public void deleteTopSite_deleteSuccessfully() {
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ScreenNavigatorTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ScreenNavigatorTest.java
@@ -49,11 +49,6 @@ public class ScreenNavigatorTest {
         activity = activityTestRule.launchActivity(new Intent());
     }
 
-    @After
-    public void tearDown() {
-        activityTestRule.getActivity().finishAndRemoveTask();
-    }
-
     /**
      * Test whether showBrowserScreen() can load and bring browser screen to foreground properly
      */

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SearchSuggestionTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SearchSuggestionTest.java
@@ -14,8 +14,6 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.test.uiautomator.UiObjectNotFoundException;
 
-import org.json.JSONException;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,11 +53,6 @@ public class SearchSuggestionTest {
         SearchEngineManager.getInstance().loadSearchEngines(InstrumentationRegistry.getContext());
         AndroidTestUtils.beforeTest();
         context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-    }
-
-    @After
-    public void tearDown() {
-        activityTestRule.getActivity().finishAndRemoveTask();
     }
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/focus/activity/TakeScreenshotTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/TakeScreenshotTest.java
@@ -66,7 +66,6 @@ public class TakeScreenshotTest {
         if (screenshotIdlingResource != null) {
             IdlingRegistry.getInstance().unregister(screenshotIdlingResource);
         }
-        activityTestRule.getActivity().finishAndRemoveTask();
     }
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/focus/activity/TurboModeTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/TurboModeTest.java
@@ -11,7 +11,6 @@ import android.support.test.espresso.Espresso;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,11 +39,6 @@ public class TurboModeTest {
     public void setUp() {
         AndroidTestUtils.beforeTest(false);
         activityTestRule.launchActivity(new Intent());
-    }
-
-    @After
-    public void tearDown() {
-        activityTestRule.getActivity().finishAndRemoveTask();
     }
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/focus/activity/WebGeolocationPermissionTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/WebGeolocationPermissionTest.java
@@ -16,7 +16,6 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.rule.GrantPermissionRule;
 import android.support.test.runner.AndroidJUnit4;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -99,11 +98,6 @@ public class WebGeolocationPermissionTest {
     @Before
     public void setUp() {
         AndroidTestUtils.beforeTest();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        activityRule.getActivity().finishAndRemoveTask();
     }
 
     @Test


### PR DESCRIPTION
Since ActivityTestRule will call finishActivity() after each test is executed, finishAndRemoveTask() in tearDown() is redundant. See: 
https://android.googlesource.com/platform/frameworks/testing/+/android-support-test/rules/src/main/java/android/support/test/rule/ActivityTestRule.java#333