### PR TITLE
telemetry: send event if set-default-browser service failed

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
@@ -791,6 +791,16 @@ public final class TelemetryWrapper {
 
     }
 
+    public static void onDefaultBrowserServiceFailed(Context context) {
+        TelemetryEvent.create(Category.ACTION, Method.CHANGE, Object.DEFAULT_BROWSER)
+                .extra(Extra.SUCCESS, Boolean.toString(false))
+                .queue();
+
+        FirebaseEvent.create(Category.ACTION, Method.CHANGE, Object.DEFAULT_BROWSER)
+                .param(Extra.SUCCESS, Boolean.toString(false))
+                .queue(context);
+    }
+
     public static void promoteShareClickEvent(Context context, String value, String source) {
         TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.PROMOTE_SHARE, value)
                 .extra(Extra.SOURCE, source)

--- a/app/src/main/java/org/mozilla/focus/widget/DefaultBrowserPreference.java
+++ b/app/src/main/java/org/mozilla/focus/widget/DefaultBrowserPreference.java
@@ -24,6 +24,7 @@ import android.widget.Switch;
 import org.mozilla.focus.R;
 import org.mozilla.focus.activity.InfoActivity;
 import org.mozilla.focus.components.ComponentToggleService;
+import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.utils.Browsers;
 import org.mozilla.focus.utils.Settings;
 import org.mozilla.focus.utils.SupportUtils;
@@ -227,9 +228,16 @@ public class DefaultBrowserPreference extends Preference {
             // to remove notification which created by Service
             NotificationManagerCompat.from(context).cancel(ComponentToggleService.NOTIFICATION_ID);
 
-            // if service finished its job, lets fire an intent to choose myself as default browser
             final boolean isDefaultBrowser = Browsers.isDefaultBrowser(context);
             final boolean hasDefaultBrowser = Browsers.hasDefaultBrowser(context);
+
+            // The default-browser-config should be cleared, if the service finished its job.
+            // if not been cleared, we regards it as 'fail'
+            if (hasDefaultBrowser && !isDefaultBrowser) {
+                TelemetryWrapper.onDefaultBrowserServiceFailed(context);
+            }
+
+            // if service finished its job, lets fire an intent to choose myself as default browser
             if (!isDefaultBrowser && !hasDefaultBrowser) {
                 pref.triggerWebOpen();
             }


### PR DESCRIPTION
Once the service finished then back to Preference, there should be no
default-browser. If it do not be cleared, we regards it as 'failed' and
send a event to inform us.