### PR TITLE
Use Kotlin in the real world

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -211,6 +211,8 @@ dependencies {
 
     implementation project(':firebase')
 
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}"
+
     implementation "com.android.support:support-v4:${Versions.support}"
     implementation "com.android.support:appcompat-v7:${Versions.support}"
     implementation "com.android.support:customtabs:${Versions.support}"
@@ -254,8 +256,6 @@ dependencies {
     })
     androidTestImplementation "com.android.support.test.espresso:espresso-web:${Versions.espresso}"
     androidTestImplementation "com.android.support.test.espresso:espresso-intents:${Versions.espresso}"
-    androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}"
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}"
     androidTestUtil "com.android.support.test:orchestrator:${Versions.test_runner}"
 
     // LeakCanary


### PR DESCRIPTION
ktx only works for API 28+.
So we just use pure Koltin.