### PR TITLE
Protect Watcher events from accessing uninitialized val created by Ac…

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/EditBookmarkActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/EditBookmarkActivity.kt
@@ -51,8 +51,10 @@ class EditBookmarkActivity : AppCompatActivity() {
         }
 
         override fun afterTextChanged(s: Editable?) {
-            nameChanged = s.toString() != originalName
-            setupMenuItemSave()
+            if(::bookmark.isInitialized) {
+                nameChanged = s.toString() != originalName
+                setupMenuItemSave()
+            }
         }
     }
     private val locationWatcher: TextWatcher = object : TextWatcher {
@@ -65,9 +67,11 @@ class EditBookmarkActivity : AppCompatActivity() {
         }
 
         override fun afterTextChanged(s: Editable?) {
-            locationChanged = s.toString() != originalLocation
-            locationEmpty = TextUtils.isEmpty(s)
-            setupMenuItemSave()
+            if(::bookmark.isInitialized) {
+                locationChanged = s.toString() != originalLocation
+                locationEmpty = TextUtils.isEmpty(s)
+                setupMenuItemSave()
+            }
         }
     }
 


### PR DESCRIPTION
…tivity re-creation

Root cause:

```
viewModel.getBookmarkById(itemId).observe(this, Observer<BookmarkModel> { bookmarkModel ->
            bookmarkModel?.apply {
                bookmark = bookmarkModel
                editTextName.setText(bookmark.title)
                editTextLocation.setText(bookmark.url)
            }
        })
```

Now we're using the Livedata, so the initialization of bookmark is delayed.