### PR TITLE
Let DB and TabsSession use different data class for a Tab

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/SaveRestoreTabsTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SaveRestoreTabsTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mozilla.focus.Inject;
 import org.mozilla.focus.R;
-import org.mozilla.focus.persistence.TabModel;
+import org.mozilla.focus.persistence.TabEntity;
 import org.mozilla.focus.persistence.TabsDatabase;
 import org.mozilla.focus.utils.AndroidTestUtils;
 
@@ -27,8 +27,8 @@ import static org.hamcrest.core.AllOf.allOf;
 @RunWith(AndroidJUnit4.class)
 public class SaveRestoreTabsTest {
 
-    private static final TabModel TAB = new TabModel("TEST_ID", "ID_HOME", "Yahoo TW", "https://tw.yahoo.com");
-    private static final TabModel TAB_2 = new TabModel("TEST_ID_2", TAB.getId(), "Google", "https://www.google.com");
+    private static final TabEntity TAB = new TabEntity("TEST_ID", "ID_HOME", "Yahoo TW", "https://tw.yahoo.com");
+    private static final TabEntity TAB_2 = new TabEntity("TEST_ID_2", TAB.getId(), "Google", "https://www.google.com");
 
     private TabsDatabase tabsDatabase;
 

--- a/app/src/androidTest/java/org/mozilla/focus/persistence/TabDaoTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/persistence/TabDaoTest.java
@@ -22,8 +22,8 @@ import static org.junit.Assert.assertEquals;
 public class TabDaoTest {
 
     private static final String TEST_DB_NAME = "migration-test";
-    private static final TabModel TAB = new TabModel("TEST_ID", "ID_HOME", "Yahoo TW", "https://tw.yahoo.com");
-    private static final TabModel TAB_2 = new TabModel("TEST_ID_2", TAB.getId(), "Google", "https://www.google.com");
+    private static final TabEntity TAB = new TabEntity("TEST_ID", "ID_HOME", "Yahoo TW", "https://tw.yahoo.com");
+    private static final TabEntity TAB_2 = new TabEntity("TEST_ID_2", TAB.getId(), "Google", "https://www.google.com");
 
     private TabsDatabase tabsDatabase;
 
@@ -51,7 +51,7 @@ public class TabDaoTest {
         tabsDatabase.tabDao().insertTabs(TAB);
 
         // The tab can be retrieved
-        List<TabModel> dbTabs = tabsDatabase.tabDao().getTabs();
+        List<TabEntity> dbTabs = tabsDatabase.tabDao().getTabs();
         assertTabEquals(TAB, dbTabs.get(0));
     }
 
@@ -61,7 +61,7 @@ public class TabDaoTest {
         tabsDatabase.tabDao().insertTabs(TAB, TAB_2);
 
         // The tab list can be retrieved
-        List<TabModel> dbTabs = tabsDatabase.tabDao().getTabs();
+        List<TabEntity> dbTabs = tabsDatabase.tabDao().getTabs();
         assertEquals(2, dbTabs.size());
         assertTabEquals(TAB, dbTabs.get(0));
         assertTabEquals(TAB_2, dbTabs.get(1));
@@ -73,11 +73,11 @@ public class TabDaoTest {
         tabsDatabase.tabDao().insertTabs(TAB);
 
         // When we are updating the title of the tab
-        TabModel updatedTab = new TabModel(TAB.getId(), TAB.getParentId(), "new title", TAB.getUrl());
+        TabEntity updatedTab = new TabEntity(TAB.getId(), TAB.getParentId(), "new title", TAB.getUrl());
         tabsDatabase.tabDao().insertTabs(updatedTab);
 
         // The retrieved tab has the updated title
-        List<TabModel> dbTabs = tabsDatabase.tabDao().getTabs();
+        List<TabEntity> dbTabs = tabsDatabase.tabDao().getTabs();
         assertTabEquals(updatedTab, dbTabs.get(0));
     }
 
@@ -90,7 +90,7 @@ public class TabDaoTest {
         tabsDatabase.tabDao().deleteTab(TAB);
 
         // The tab is no longer in the data source
-        List<TabModel> dbTabs = tabsDatabase.tabDao().getTabs();
+        List<TabEntity> dbTabs = tabsDatabase.tabDao().getTabs();
         assertEquals(0, dbTabs.size());
     }
 
@@ -103,7 +103,7 @@ public class TabDaoTest {
         tabsDatabase.tabDao().deleteAllTabs();
 
         // The tab is no longer in the data source
-        List<TabModel> dbTabs = tabsDatabase.tabDao().getTabs();
+        List<TabEntity> dbTabs = tabsDatabase.tabDao().getTabs();
         assertEquals(0, dbTabs.size());
     }
 
@@ -121,24 +121,24 @@ public class TabDaoTest {
 
         // MigrationTestHelper automatically verifies the schema changes, but not the data validity
         // Validate that the data was migrated properly.
-        List<TabModel> dbTabs = getMigratedRoomDatabase().tabDao().getTabs();
+        List<TabEntity> dbTabs = getMigratedRoomDatabase().tabDao().getTabs();
         assertEquals(2, dbTabs.size());
         assertTabEquals(TAB, dbTabs.get(0));
         assertTabEquals(TAB_2, dbTabs.get(1));
     }
 
-    private void insertTabV1(TabModel tabModel, SupportSQLiteDatabase db) {
+    private void insertTabV1(TabEntity tabEntity, SupportSQLiteDatabase db) {
         ContentValues values = new ContentValues();
-        values.put("tab_id", tabModel.getId());
-        values.put("tab_parent_id", tabModel.getParentId());
-        values.put("tab_title", tabModel.getTitle());
-        values.put("tab_url", tabModel.getUrl());
+        values.put("tab_id", tabEntity.getId());
+        values.put("tab_parent_id", tabEntity.getParentId());
+        values.put("tab_title", tabEntity.getTitle());
+        values.put("tab_url", tabEntity.getUrl());
         values.put("tab_thumbnail_uri", "");
         values.put("webview_state_uri", "");
         db.insert("tabs", SQLiteDatabase.CONFLICT_REPLACE, values);
     }
 
-    private void assertTabEquals(TabModel expectedTab, TabModel actualTab) {
+    private void assertTabEquals(TabEntity expectedTab, TabEntity actualTab) {
         assertEquals(expectedTab.getId(), actualTab.getId());
         assertEquals(expectedTab.getParentId(), actualTab.getParentId());
         assertEquals(expectedTab.getTitle(), actualTab.getTitle());

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -49,7 +49,7 @@ import org.mozilla.focus.notification.NotificationId;
 import org.mozilla.focus.notification.NotificationUtil;
 import org.mozilla.focus.notification.RocketMessagingService;
 import org.mozilla.focus.persistence.BookmarksDatabase;
-import org.mozilla.focus.persistence.TabModel;
+import org.mozilla.focus.persistence.TabEntity;
 import org.mozilla.focus.repository.BookmarkRepository;
 import org.mozilla.focus.screenshot.ScreenshotGridFragment;
 import org.mozilla.focus.screenshot.ScreenshotViewerActivity;
@@ -78,7 +78,6 @@ import org.mozilla.focus.utils.ShortcutUtils;
 import org.mozilla.focus.utils.StorageUtils;
 import org.mozilla.focus.utils.UrlUtils;
 import org.mozilla.focus.viewmodel.BookmarkViewModel;
-import org.mozilla.focus.web.BrowsingSession;
 import org.mozilla.focus.web.WebViewProvider;
 import org.mozilla.focus.widget.DefaultBrowserPreference;
 import org.mozilla.focus.widget.FragmentListener;
@@ -932,9 +931,9 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
     }
 
     @Override
-    public void onQueryComplete(List<TabModel> tabModelList, String currentTabId) {
+    public void onQueryComplete(List<TabEntity> tabEntityList, String currentTabId) {
         isTabRestoredComplete = true;
-        getTabsSession().restoreTabs(tabModelList, currentTabId);
+        getTabsSession().restoreTabs(tabEntityList, currentTabId);
         Tab currentTab = getTabsSession().getFocusTab();
         if (currentTab != null) {
             screenNavigator.restoreBrowserScreen(currentTab.getId(), !getSupportFragmentManager().isStateSaved());
@@ -951,13 +950,13 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
             return;
         }
 
-        List<TabModel> tabModelListForPersistence = getTabsSession().getTabModelListForPersistence();
+        List<TabEntity> tabEntityListForPersistence = getTabsSession().getTabModelListForPersistence();
         final String currentTabId = (getTabsSession().getFocusTab() != null)
                 ? getTabsSession().getFocusTab().getId()
                 : null;
 
-        if (tabModelListForPersistence != null) {
-            TabModelStore.getInstance(this).saveTabs(this, tabModelListForPersistence, currentTabId, null);
+        if (tabEntityListForPersistence != null) {
+            TabModelStore.getInstance(this).saveTabs(this, tabEntityListForPersistence, currentTabId, null);
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -49,12 +49,12 @@ import org.mozilla.focus.notification.NotificationId;
 import org.mozilla.focus.notification.NotificationUtil;
 import org.mozilla.focus.notification.RocketMessagingService;
 import org.mozilla.focus.persistence.BookmarksDatabase;
-import org.mozilla.focus.persistence.TabEntity;
+import org.mozilla.focus.persistence.TabModelStore;
 import org.mozilla.focus.repository.BookmarkRepository;
 import org.mozilla.focus.screenshot.ScreenshotGridFragment;
 import org.mozilla.focus.screenshot.ScreenshotViewerActivity;
 import org.mozilla.focus.tabs.Tab;
-import org.mozilla.focus.persistence.TabModelStore;
+import org.mozilla.focus.tabs.TabModel;
 import org.mozilla.focus.tabs.TabView;
 import org.mozilla.focus.tabs.TabViewProvider;
 import org.mozilla.focus.tabs.TabsSession;
@@ -931,9 +931,9 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
     }
 
     @Override
-    public void onQueryComplete(List<TabEntity> tabEntityList, String currentTabId) {
+    public void onQueryComplete(List<TabModel> tabModelList, String currentTabId) {
         isTabRestoredComplete = true;
-        getTabsSession().restoreTabs(tabEntityList, currentTabId);
+        getTabsSession().restoreTabs(tabModelList, currentTabId);
         Tab currentTab = getTabsSession().getFocusTab();
         if (currentTab != null) {
             screenNavigator.restoreBrowserScreen(currentTab.getId(), !getSupportFragmentManager().isStateSaved());
@@ -950,13 +950,13 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
             return;
         }
 
-        List<TabEntity> tabEntityListForPersistence = getTabsSession().getTabModelListForPersistence();
+        List<TabModel> tabModelListForPersistence = getTabsSession().getTabModelListForPersistence();
         final String currentTabId = (getTabsSession().getFocusTab() != null)
                 ? getTabsSession().getFocusTab().getId()
                 : null;
 
-        if (tabEntityListForPersistence != null) {
-            TabModelStore.getInstance(this).saveTabs(this, tabEntityListForPersistence, currentTabId, null);
+        if (tabModelListForPersistence != null) {
+            TabModelStore.getInstance(this).saveTabs(this, tabModelListForPersistence, currentTabId, null);
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -54,7 +54,7 @@ import org.mozilla.focus.repository.BookmarkRepository;
 import org.mozilla.focus.screenshot.ScreenshotGridFragment;
 import org.mozilla.focus.screenshot.ScreenshotViewerActivity;
 import org.mozilla.focus.tabs.Tab;
-import org.mozilla.focus.tabs.TabModelStore;
+import org.mozilla.focus.persistence.TabModelStore;
 import org.mozilla.focus.tabs.TabView;
 import org.mozilla.focus.tabs.TabViewProvider;
 import org.mozilla.focus.tabs.TabsSession;

--- a/app/src/main/java/org/mozilla/focus/persistence/TabDao.java
+++ b/app/src/main/java/org/mozilla/focus/persistence/TabDao.java
@@ -13,19 +13,19 @@ import java.util.List;
 public abstract class TabDao {
 
     @Query("SELECT * FROM tabs")
-    public abstract List<TabModel> getTabs();
+    public abstract List<TabEntity> getTabs();
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    public abstract void insertTabs(TabModel... tab);
+    public abstract void insertTabs(TabEntity... tab);
 
     @Delete
-    public abstract void deleteTab(TabModel tab);
+    public abstract void deleteTab(TabEntity tab);
 
     @Query("DELETE FROM tabs")
     public abstract void deleteAllTabs();
 
     @Transaction
-    public void deleteAllTabsAndInsertTabsInTransaction(TabModel... tab) {
+    public void deleteAllTabsAndInsertTabsInTransaction(TabEntity... tab) {
         deleteAllTabs();
         insertTabs(tab);
     }

--- a/app/src/main/java/org/mozilla/focus/persistence/TabEntity.java
+++ b/app/src/main/java/org/mozilla/focus/persistence/TabEntity.java
@@ -4,8 +4,6 @@ import android.arch.persistence.room.ColumnInfo;
 import android.arch.persistence.room.Entity;
 import android.arch.persistence.room.Ignore;
 import android.arch.persistence.room.PrimaryKey;
-import android.graphics.Bitmap;
-import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
@@ -37,26 +35,6 @@ public class TabEntity {
 
     @ColumnInfo(name = "tab_url")
     private String url;
-
-    /**
-     * Thumbnail bitmap for tab previewing.
-     */
-    @Ignore
-    private Bitmap thumbnail;
-
-    /**
-     * Favicon bitmap for tab tray item.
-     */
-    @Ignore
-    private Bitmap favicon;
-
-    /**
-     * ViewState for this Tab. Usually to fill by WebView.saveViewState(Bundle)
-     * Set it as @Ignore to avoid storing this field into database.
-     * It will be serialized to a file and save the uri path into webViewStateUri field.
-     */
-    @Ignore
-    private Bundle webViewState;
 
     @NonNull
     public String getId() {
@@ -91,30 +69,6 @@ public class TabEntity {
         this.url = url;
     }
 
-    public Bitmap getThumbnail() {
-        return thumbnail;
-    }
-
-    public void setThumbnail(Bitmap thumbnail) {
-        this.thumbnail = thumbnail;
-    }
-
-    public Bitmap getFavicon() {
-        return favicon;
-    }
-
-    public void setFavicon(Bitmap favicon) {
-        this.favicon = favicon;
-    }
-
-    public Bundle getWebViewState() {
-        return webViewState;
-    }
-
-    public void setWebViewState(Bundle webViewState) {
-        this.webViewState = webViewState;
-    }
-
     public boolean isValid() {
         final boolean hasId = !TextUtils.isEmpty(this.getId());
         final boolean hasUrl = !TextUtils.isEmpty(this.getUrl());
@@ -128,10 +82,7 @@ public class TabEntity {
                 "id='" + id + '\'' +
                 ", parentId='" + parentId + '\'' +
                 ", title='" + title + '\'' +
-                ", url='" + url + '\'' +
-                ", thumbnail=" + thumbnail +
-                ", favicon=" + favicon +
-                ", webViewState=" + webViewState +
+                ", url='" + url +
                 '}';
     }
 }

--- a/app/src/main/java/org/mozilla/focus/persistence/TabEntity.java
+++ b/app/src/main/java/org/mozilla/focus/persistence/TabEntity.java
@@ -10,14 +10,14 @@ import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 @Entity(tableName = "tabs")
-public class TabModel {
+public class TabEntity {
 
     @Ignore
-    public TabModel(String id, String parentId) {
+    public TabEntity(String id, String parentId) {
         this(id, parentId, "", "");
     }
 
-    public TabModel(String id, String parentId, String title, String url) {
+    public TabEntity(String id, String parentId, String title, String url) {
         this.id = id;
         this.parentId = parentId;
         this.title = title;
@@ -124,7 +124,7 @@ public class TabModel {
 
     @Override
     public String toString() {
-        return "TabModel{" +
+        return "TabEntity{" +
                 "id='" + id + '\'' +
                 ", parentId='" + parentId + '\'' +
                 ", title='" + title + '\'' +

--- a/app/src/main/java/org/mozilla/focus/persistence/TabModelStore.java
+++ b/app/src/main/java/org/mozilla/focus/persistence/TabModelStore.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 
 import org.mozilla.focus.Inject;
 import org.mozilla.focus.R;
+import org.mozilla.focus.tabs.TabModel;
 import org.mozilla.focus.utils.FileUtils;
 
 import java.io.File;
@@ -26,7 +27,7 @@ public class TabModelStore {
     private TabsDatabase tabsDatabase;
 
     public interface AsyncQueryListener {
-        void onQueryComplete(List<TabEntity> tabEntityList, String focusTabId);
+        void onQueryComplete(List<TabModel> tabModelList, String focusTabId);
     }
 
     public interface AsyncSaveListener {
@@ -53,7 +54,7 @@ public class TabModelStore {
     }
 
     public void saveTabs(@NonNull final Context context,
-                         @NonNull final List<TabEntity> tabEntityList,
+                         @NonNull final List<TabModel> tabModelList,
                          @Nullable final String focusTabId,
                          @Nullable final AsyncSaveListener listener) {
 
@@ -62,7 +63,7 @@ public class TabModelStore {
                 .putString(context.getResources().getString(R.string.pref_key_focus_tab_id), focusTabId)
                 .apply();
 
-        new SaveTabsTask(context, tabsDatabase, listener).executeOnExecutor(SERIAL_EXECUTOR, tabEntityList.toArray(new TabEntity[0]));
+        new SaveTabsTask(context, tabsDatabase, listener).executeOnExecutor(SERIAL_EXECUTOR, tabModelList.toArray(new TabModel[0]));
     }
 
     private static class QueryTabsTask extends AsyncTask<Void, Void, List<TabEntity>> {

--- a/app/src/main/java/org/mozilla/focus/persistence/TabModelStore.java
+++ b/app/src/main/java/org/mozilla/focus/persistence/TabModelStore.java
@@ -1,4 +1,4 @@
-package org.mozilla.focus.tabs;
+package org.mozilla.focus.persistence;
 
 import android.content.Context;
 import android.os.AsyncTask;
@@ -8,8 +8,6 @@ import android.support.annotation.Nullable;
 
 import org.mozilla.focus.Inject;
 import org.mozilla.focus.R;
-import org.mozilla.focus.persistence.TabEntity;
-import org.mozilla.focus.persistence.TabsDatabase;
 import org.mozilla.focus.utils.FileUtils;
 
 import java.io.File;

--- a/app/src/main/java/org/mozilla/focus/persistence/TabsDatabase.java
+++ b/app/src/main/java/org/mozilla/focus/persistence/TabsDatabase.java
@@ -8,7 +8,7 @@ import android.arch.persistence.room.migration.Migration;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
-@Database(entities = {TabModel.class}, version = 2)
+@Database(entities = {TabEntity.class}, version = 2)
 public abstract class TabsDatabase extends RoomDatabase {
 
     private static volatile TabsDatabase instance;

--- a/app/src/main/java/org/mozilla/focus/tabs/Tab.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/Tab.java
@@ -14,7 +14,6 @@ import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 
-import org.mozilla.focus.persistence.TabEntity;
 import org.mozilla.focus.web.DownloadCallback;
 
 import java.util.UUID;
@@ -31,32 +30,32 @@ public class Tab {
     private static TabViewClient sDefViewClient = new TabViewClient();
     private static TabChromeClient sDefChromeClient = new TabChromeClient();
 
-    private TabEntity tabEntity;
+    private TabModel tabModel;
     private TabView tabView;
     private TabViewClient tabViewClient = sDefViewClient;
     private TabChromeClient tabChromeClient = sDefChromeClient;
     private DownloadCallback downloadCallback;
 
     public Tab() {
-        this(new TabEntity(UUID.randomUUID().toString(), ""));
+        this(new TabModel(UUID.randomUUID().toString(), "", "", ""));
     }
 
-    public Tab(@NonNull TabEntity model) {
-        this.tabEntity = model;
+    public Tab(@NonNull TabModel model) {
+        this.tabModel = model;
     }
 
-    public TabEntity getSaveModel() {
-        if (tabEntity.getWebViewState() == null) {
-            tabEntity.setWebViewState(new Bundle());
+    public TabModel getSaveModel() {
+        if (tabModel.getWebViewState() == null) {
+            tabModel.setWebViewState(new Bundle());
         }
 
         if (tabView != null) {
-            tabEntity.setTitle(tabView.getTitle());
-            tabEntity.setUrl(tabView.getUrl());
-            tabView.saveViewState(tabEntity.getWebViewState());
+            tabModel.setTitle(tabView.getTitle());
+            tabModel.setUrl(tabView.getUrl());
+            tabView.saveViewState(tabModel.getWebViewState());
         }
 
-        return tabEntity;
+        return tabModel;
     }
 
     @Nullable
@@ -65,12 +64,12 @@ public class Tab {
     }
 
     public String getId() {
-        return this.tabEntity.getId();
+        return this.tabModel.getId();
     }
 
     public String getTitle() {
         if (tabView == null) {
-            return tabEntity.getTitle();
+            return tabModel.getTitle();
         } else {
             return tabView.getTitle();
         }
@@ -78,11 +77,11 @@ public class Tab {
 
     public String getUrl() {
         if (tabView == null) {
-            if (tabEntity == null) {
+            if (tabModel == null) {
                 Log.d(TAG, "trying to get url from a tab which has no view nor model");
                 return null;
             } else {
-                return tabEntity.getUrl();
+                return tabModel.getUrl();
             }
         } else {
             return tabView.getUrl();
@@ -91,8 +90,8 @@ public class Tab {
 
     @Nullable
     public Bitmap getFavicon() {
-        if (tabEntity != null) {
-            return tabEntity.getFavicon();
+        if (tabModel != null) {
+            return tabModel.getFavicon();
         }
         return null;
     }
@@ -175,24 +174,24 @@ public class Tab {
     }
 
     /* package */ void setParentId(@Nullable String id) {
-        this.tabEntity.setParentId(id);
+        this.tabModel.setParentId(id);
     }
 
     @Nullable
     /* package */ String getParentId() {
-        return this.tabEntity.getParentId();
+        return this.tabModel.getParentId();
     }
 
     /* package */ void setTitle(@NonNull String title) {
-        tabEntity.setTitle(title);
+        tabModel.setTitle(title);
     }
 
     /* package */ void setUrl(@NonNull String url) {
-        tabEntity.setUrl(url);
+        tabModel.setUrl(url);
     }
 
     /* package */ void setFavicon(Bitmap icon) {
-        tabEntity.setFavicon(icon);
+        tabModel.setFavicon(icon);
     }
 
     /* package */ TabView initializeView(@NonNull final TabViewProvider provider) {
@@ -204,8 +203,8 @@ public class Tab {
             tabView.setChromeClient(tabChromeClient);
             tabView.setDownloadCallback(downloadCallback);
 
-            if (tabEntity.getWebViewState() != null) {
-                tabView.restoreViewState(tabEntity.getWebViewState());
+            if (tabModel.getWebViewState() != null) {
+                tabView.restoreViewState(tabModel.getWebViewState());
             } else if (!TextUtils.isEmpty(url)) {
                 tabView.loadUrl(url);
             }
@@ -221,7 +220,7 @@ public class Tab {
             view.setDrawingCacheEnabled(true);
             final Bitmap bitmap = tabView.getDrawingCache(true);
             if (bitmap != null) {
-                tabEntity.setThumbnail(Bitmap.createBitmap(bitmap));
+                tabModel.setThumbnail(Bitmap.createBitmap(bitmap));
                 bitmap.recycle();
             }
             view.setDrawingCacheEnabled(false);
@@ -230,6 +229,6 @@ public class Tab {
 
     // TODO: not implement completely
     private Bitmap getThumbnail() {
-        return tabEntity.getThumbnail();
+        return tabModel.getThumbnail();
     }
 }

--- a/app/src/main/java/org/mozilla/focus/tabs/Tab.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/Tab.java
@@ -14,7 +14,7 @@ import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 
-import org.mozilla.focus.persistence.TabModel;
+import org.mozilla.focus.persistence.TabEntity;
 import org.mozilla.focus.web.DownloadCallback;
 
 import java.util.UUID;
@@ -31,32 +31,32 @@ public class Tab {
     private static TabViewClient sDefViewClient = new TabViewClient();
     private static TabChromeClient sDefChromeClient = new TabChromeClient();
 
-    private TabModel tabModel;
+    private TabEntity tabEntity;
     private TabView tabView;
     private TabViewClient tabViewClient = sDefViewClient;
     private TabChromeClient tabChromeClient = sDefChromeClient;
     private DownloadCallback downloadCallback;
 
     public Tab() {
-        this(new TabModel(UUID.randomUUID().toString(), ""));
+        this(new TabEntity(UUID.randomUUID().toString(), ""));
     }
 
-    public Tab(@NonNull TabModel model) {
-        this.tabModel = model;
+    public Tab(@NonNull TabEntity model) {
+        this.tabEntity = model;
     }
 
-    public TabModel getSaveModel() {
-        if (tabModel.getWebViewState() == null) {
-            tabModel.setWebViewState(new Bundle());
+    public TabEntity getSaveModel() {
+        if (tabEntity.getWebViewState() == null) {
+            tabEntity.setWebViewState(new Bundle());
         }
 
         if (tabView != null) {
-            tabModel.setTitle(tabView.getTitle());
-            tabModel.setUrl(tabView.getUrl());
-            tabView.saveViewState(tabModel.getWebViewState());
+            tabEntity.setTitle(tabView.getTitle());
+            tabEntity.setUrl(tabView.getUrl());
+            tabView.saveViewState(tabEntity.getWebViewState());
         }
 
-        return tabModel;
+        return tabEntity;
     }
 
     @Nullable
@@ -65,12 +65,12 @@ public class Tab {
     }
 
     public String getId() {
-        return this.tabModel.getId();
+        return this.tabEntity.getId();
     }
 
     public String getTitle() {
         if (tabView == null) {
-            return tabModel.getTitle();
+            return tabEntity.getTitle();
         } else {
             return tabView.getTitle();
         }
@@ -78,11 +78,11 @@ public class Tab {
 
     public String getUrl() {
         if (tabView == null) {
-            if (tabModel == null) {
+            if (tabEntity == null) {
                 Log.d(TAG, "trying to get url from a tab which has no view nor model");
                 return null;
             } else {
-                return tabModel.getUrl();
+                return tabEntity.getUrl();
             }
         } else {
             return tabView.getUrl();
@@ -91,8 +91,8 @@ public class Tab {
 
     @Nullable
     public Bitmap getFavicon() {
-        if (tabModel != null) {
-            return tabModel.getFavicon();
+        if (tabEntity != null) {
+            return tabEntity.getFavicon();
         }
         return null;
     }
@@ -175,24 +175,24 @@ public class Tab {
     }
 
     /* package */ void setParentId(@Nullable String id) {
-        this.tabModel.setParentId(id);
+        this.tabEntity.setParentId(id);
     }
 
     @Nullable
     /* package */ String getParentId() {
-        return this.tabModel.getParentId();
+        return this.tabEntity.getParentId();
     }
 
     /* package */ void setTitle(@NonNull String title) {
-        tabModel.setTitle(title);
+        tabEntity.setTitle(title);
     }
 
     /* package */ void setUrl(@NonNull String url) {
-        tabModel.setUrl(url);
+        tabEntity.setUrl(url);
     }
 
     /* package */ void setFavicon(Bitmap icon) {
-        tabModel.setFavicon(icon);
+        tabEntity.setFavicon(icon);
     }
 
     /* package */ TabView initializeView(@NonNull final TabViewProvider provider) {
@@ -204,8 +204,8 @@ public class Tab {
             tabView.setChromeClient(tabChromeClient);
             tabView.setDownloadCallback(downloadCallback);
 
-            if (tabModel.getWebViewState() != null) {
-                tabView.restoreViewState(tabModel.getWebViewState());
+            if (tabEntity.getWebViewState() != null) {
+                tabView.restoreViewState(tabEntity.getWebViewState());
             } else if (!TextUtils.isEmpty(url)) {
                 tabView.loadUrl(url);
             }
@@ -221,7 +221,7 @@ public class Tab {
             view.setDrawingCacheEnabled(true);
             final Bitmap bitmap = tabView.getDrawingCache(true);
             if (bitmap != null) {
-                tabModel.setThumbnail(Bitmap.createBitmap(bitmap));
+                tabEntity.setThumbnail(Bitmap.createBitmap(bitmap));
                 bitmap.recycle();
             }
             view.setDrawingCacheEnabled(false);
@@ -230,6 +230,6 @@ public class Tab {
 
     // TODO: not implement completely
     private Bitmap getThumbnail() {
-        return tabModel.getThumbnail();
+        return tabEntity.getThumbnail();
     }
 }

--- a/app/src/main/java/org/mozilla/focus/tabs/TabModel.kt
+++ b/app/src/main/java/org/mozilla/focus/tabs/TabModel.kt
@@ -1,0 +1,32 @@
+package org.mozilla.focus.tabs
+
+import android.graphics.Bitmap
+import android.os.Bundle
+
+data class TabModel(
+        val id: String,
+        var parentId: String?,
+        var title: String?,
+        var url: String?) {
+
+    /**
+     * Favicon bitmap for tab tray item.
+     */
+    var favicon: Bitmap? = null
+
+    /**
+     * Thumbnail bitmap for tab previewing.
+     */
+    var thumbnail: Bitmap? = null
+
+    /**
+     * ViewState for this Tab. Usually to fill by WebView.saveViewState(Bundle)
+     * Set it as @Ignore to avoid storing this field into database.
+     * It will be serialized to a file and save the uri path into webViewStateUri field.
+     */
+    var webViewState: Bundle? = null
+
+    fun isValid(): Boolean {
+        return id.isNotBlank() && url?.isNotBlank()!!
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/tabs/TabsSession.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/TabsSession.java
@@ -19,7 +19,6 @@ import android.webkit.GeolocationPermissions;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 
-import org.mozilla.focus.persistence.TabEntity;
 import org.mozilla.focus.tabs.utils.TabUtil;
 import org.mozilla.focus.web.DownloadCallback;
 
@@ -72,7 +71,7 @@ public class TabsSession {
     }
 
     /**
-     * To append tabs from a list of TabEntity. If the specified focusTabId exists, the tab associate
+     * To append tabs from a list of TabModel. If the specified focusTabId exists, the tab associate
      * to the id will be focused, otherwise no tab will be focused.
      * <p>
      * This is asynchronous call.
@@ -80,9 +79,9 @@ public class TabsSession {
      *
      * @param models
      */
-    public void restoreTabs(@NonNull final List<TabEntity> models, String focusTabId) {
+    public void restoreTabs(@NonNull final List<TabModel> models, String focusTabId) {
         int insertPos = 0;
-        for (final TabEntity model : models) {
+        for (final TabModel model : models) {
             if (!model.isValid()) {
                 continue;
             }
@@ -104,10 +103,10 @@ public class TabsSession {
     /**
      * To get data of tabs to store in persistent storage.
      *
-     * @return created TabEntity of tabs in this session.
+     * @return created TabModel of tabs in this session.
      */
-    public List<TabEntity> getTabModelListForPersistence() {
-        final List<TabEntity> models = new ArrayList<>();
+    public List<TabModel> getTabModelListForPersistence() {
+        final List<TabModel> models = new ArrayList<>();
         for (final Tab tab : tabs) {
             models.add(tab.getSaveModel());
         }

--- a/app/src/main/java/org/mozilla/focus/tabs/TabsSession.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/TabsSession.java
@@ -19,7 +19,7 @@ import android.webkit.GeolocationPermissions;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 
-import org.mozilla.focus.persistence.TabModel;
+import org.mozilla.focus.persistence.TabEntity;
 import org.mozilla.focus.tabs.utils.TabUtil;
 import org.mozilla.focus.web.DownloadCallback;
 
@@ -72,7 +72,7 @@ public class TabsSession {
     }
 
     /**
-     * To append tabs from a list of TabModel. If the specified focusTabId exists, the tab associate
+     * To append tabs from a list of TabEntity. If the specified focusTabId exists, the tab associate
      * to the id will be focused, otherwise no tab will be focused.
      * <p>
      * This is asynchronous call.
@@ -80,9 +80,9 @@ public class TabsSession {
      *
      * @param models
      */
-    public void restoreTabs(@NonNull final List<TabModel> models, String focusTabId) {
+    public void restoreTabs(@NonNull final List<TabEntity> models, String focusTabId) {
         int insertPos = 0;
-        for (final TabModel model : models) {
+        for (final TabEntity model : models) {
             if (!model.isValid()) {
                 continue;
             }
@@ -104,10 +104,10 @@ public class TabsSession {
     /**
      * To get data of tabs to store in persistent storage.
      *
-     * @return created TabModel of tabs in this session.
+     * @return created TabEntity of tabs in this session.
      */
-    public List<TabModel> getTabModelListForPersistence() {
-        final List<TabModel> models = new ArrayList<>();
+    public List<TabEntity> getTabModelListForPersistence() {
+        final List<TabEntity> models = new ArrayList<>();
         for (final Tab tab : tabs) {
             models.add(tab.getSaveModel());
         }

--- a/app/src/test/java/org/mozilla/focus/persistence/TabEntityTest.java
+++ b/app/src/test/java/org/mozilla/focus/persistence/TabEntityTest.java
@@ -12,16 +12,16 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 @RunWith(RobolectricTestRunner.class)
-public class TabModelTest {
+public class TabEntityTest {
 
     @Test
     public void testSanity() {
-        Assert.assertFalse(new TabModel(null, null).isValid());
-        Assert.assertFalse(new TabModel(null, null, "title", "").isValid());
-        Assert.assertFalse(new TabModel(null, null, null, "url").isValid());
-        Assert.assertFalse(new TabModel("id", null, null, null).isValid());
+        Assert.assertFalse(new TabEntity(null, null).isValid());
+        Assert.assertFalse(new TabEntity(null, null, "title", "").isValid());
+        Assert.assertFalse(new TabEntity(null, null, null, "url").isValid());
+        Assert.assertFalse(new TabEntity("id", null, null, null).isValid());
 
-        Assert.assertTrue(new TabModel("id", null, null, "url").isValid());
-        Assert.assertTrue(new TabModel("id", null, "title", "url").isValid());
+        Assert.assertTrue(new TabEntity("id", null, null, "url").isValid());
+        Assert.assertTrue(new TabEntity("id", null, "title", "url").isValid());
     }
 }

--- a/app/src/test/java/org/mozilla/focus/tabs/TabsSessionTest.java
+++ b/app/src/test/java/org/mozilla/focus/tabs/TabsSessionTest.java
@@ -19,7 +19,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mozilla.focus.persistence.TabModel;
+import org.mozilla.focus.persistence.TabEntity;
 import org.mozilla.focus.tabs.utils.DefaultTabsChromeListener;
 import org.mozilla.focus.tabs.utils.TabUtil;
 import org.mozilla.focus.web.DownloadCallback;
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.verify;
 public class TabsSessionTest {
 
     TabsSession session;
-    final List<TabModel> models = new ArrayList<>();
+    final List<TabEntity> models = new ArrayList<>();
 
     final String[] urls = new String[]{
             "https://mozilla.org",
@@ -55,7 +55,7 @@ public class TabsSessionTest {
 
         for (int i = 0; i < urls.length; i++) {
             // use url as id for convenience
-            final TabModel model = new TabModel(urls[i], "", urls[i], urls[i]);
+            final TabEntity model = new TabEntity(urls[i], "", urls[i], urls[i]);
             models.add(model);
         }
     }

--- a/app/src/test/java/org/mozilla/focus/tabs/TabsSessionTest.java
+++ b/app/src/test/java/org/mozilla/focus/tabs/TabsSessionTest.java
@@ -19,7 +19,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mozilla.focus.persistence.TabEntity;
 import org.mozilla.focus.tabs.utils.DefaultTabsChromeListener;
 import org.mozilla.focus.tabs.utils.TabUtil;
 import org.mozilla.focus.web.DownloadCallback;
@@ -40,7 +39,7 @@ import static org.mockito.Mockito.verify;
 public class TabsSessionTest {
 
     TabsSession session;
-    final List<TabEntity> models = new ArrayList<>();
+    final List<TabModel> models = new ArrayList<>();
 
     final String[] urls = new String[]{
             "https://mozilla.org",
@@ -55,7 +54,7 @@ public class TabsSessionTest {
 
         for (int i = 0; i < urls.length; i++) {
             // use url as id for convenience
-            final TabEntity model = new TabEntity(urls[i], "", urls[i], urls[i]);
+            final TabModel model = new TabModel(urls[i], "", urls[i], urls[i]);
             models.add(model);
         }
     }


### PR DESCRIPTION
I am going to move TabsSession related implementation to another module, also want to decouple package *persistence* from package *tabs*.

This PR tries to involve `TabEntity` and data class `TabModel`.

The DB side uses `TabEntity` to store/restore data of tab. The TabsSession side uses `TabModel` to present data of a tab. TabModelStore is the bridge between `TabEntity` and `TabsSession`