### PR TITLE
refactor: to make UrlInputFragment be re-usable

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -396,6 +396,11 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
         return screenNavigator.isBrowserInForeground() ? getBrowserFragment() : null;
     }
 
+    private void openUrl(final boolean withNewTab, final Object payload) {
+        final String url = (payload != null) ? payload.toString() : null;
+        ScreenNavigator.get(this).showBrowserScreen(url, withNewTab, false);
+    }
+
     private void showMenu() {
         updateMenu();
         menu.show();
@@ -800,6 +805,12 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
                 break;
             case UPDATE_MENU:
                 this.updateMenu();
+                break;
+            case OPEN_URL_IN_CURRENT_TAB:
+                openUrl(false, payload);
+                break;
+            case OPEN_URL_IN_NEW_TAB:
+                openUrl(true, payload);
                 break;
             case SHOW_URL_INPUT:
                 if (getSupportFragmentManager().isStateSaved()) {

--- a/app/src/main/java/org/mozilla/focus/urlinput/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/urlinput/UrlInputFragment.java
@@ -18,7 +18,6 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import org.mozilla.focus.R;
-import org.mozilla.focus.navigation.ScreenNavigator;
 import org.mozilla.focus.autocomplete.UrlAutoCompleteFilter;
 import org.mozilla.focus.home.HomeFragment;
 import org.mozilla.focus.search.SearchEngineManager;
@@ -215,7 +214,6 @@ public class UrlInputFragment extends Fragment implements UrlInputContract.View,
     }
 
     /**
-     *
      * @param url the URL to open
      * @return true if open URL in new tab.
      */
@@ -226,7 +224,16 @@ public class UrlInputFragment extends Fragment implements UrlInputContract.View,
         if (args != null && args.containsKey(ARGUMENT_PARENT_FRAGMENT)) {
             openNewTab = HomeFragment.FRAGMENT_TAG.equals(args.getString(ARGUMENT_PARENT_FRAGMENT));
         }
-        ScreenNavigator.get(getContext()).showBrowserScreen(url, openNewTab, false);
+
+        final Activity activity = getActivity();
+        if (activity instanceof FragmentListener) {
+            final FragmentListener listener = (FragmentListener) activity;
+            FragmentListener.TYPE msgType = openNewTab
+                    ? FragmentListener.TYPE.OPEN_URL_IN_NEW_TAB
+                    : FragmentListener.TYPE.OPEN_URL_IN_CURRENT_TAB;
+
+            listener.onNotified(this, msgType, url);
+        }
 
         return openNewTab;
     }

--- a/app/src/main/java/org/mozilla/focus/widget/FragmentListener.java
+++ b/app/src/main/java/org/mozilla/focus/widget/FragmentListener.java
@@ -17,6 +17,8 @@ public interface FragmentListener {
 
     enum TYPE {
         OPEN_PREFERENCE, // no payload
+        OPEN_URL_IN_CURRENT_TAB, // payload is url in String
+        OPEN_URL_IN_NEW_TAB, // payload is url in String
         SHOW_URL_INPUT, // no payload
         SHOW_MENU, // no payload
         DISMISS_URL_INPUT, // payload is boolean value, true if commitAllowingStateLoss


### PR DESCRIPTION
We are going to reuse UrlInputFragment in private-browsing.
When commit a url, do not call ScreenNavigator directly, because
ScreenNavigator is for normal browsing.