### PR TITLE
pro-guard: keep fragments hold by Navigation

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -99,6 +99,10 @@ public static java.lang.String TABLENAME;
 }
 
 
+# For Fragments which be created by xml of Android Navigation Architecture Components
+-keep public class org.mozilla.rocket.** extends android.support.v4.app.Fragment
+
+
 # Integrate buddybuild leakcanary
 -dontwarn com.squareup.haha.guava.**
 -dontwarn com.squareup.haha.perflib.**


### PR DESCRIPTION
Android Navigation Architecture Compoments uses XML to create fragments,
rather than reference a class in Java code. Hence, ProGuard might drop
some fragments we actually need it.

to fix #2212