### PR TITLE
Set content-intent out of NotificationUtil.importantBuilder(this)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -353,11 +353,12 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
         PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent,
                 PendingIntent.FLAG_ONE_SHOT);
 
-        final NotificationCompat.Builder builder = NotificationUtil.importantBuilder(this, pendingIntent)
+        final NotificationCompat.Builder builder = NotificationUtil.importantBuilder(this)
                 .setContentTitle(getString(R.string.survey_notification_title, "\uD83D\uDE4C"))
                 .setContentText(getString(R.string.survey_notification_description))
                 .setStyle(new NotificationCompat.BigTextStyle().bigText(
-                        getString(R.string.survey_notification_description)));
+                        getString(R.string.survey_notification_description)))
+                .setContentIntent(pendingIntent);
 
         NotificationUtil.sendNotification(this, NotificationId.SURVEY_ON_3RD_LAUNCH, builder);
     }

--- a/app/src/main/java/org/mozilla/focus/components/ComponentToggleService.java
+++ b/app/src/main/java/org/mozilla/focus/components/ComponentToggleService.java
@@ -169,13 +169,14 @@ public class ComponentToggleService extends Service {
 
     private void startToForeground() {
         final NotificationCompat.Builder builder =
-                NotificationUtil.importantBuilder(getApplicationContext(), buildIntent());
+                NotificationUtil.importantBuilder(getApplicationContext());
 
         final Notification notification = builder
                 .setContentTitle(getString(R.string.setting_default_browser_notification_title))
                 .setContentText(getString(R.string.setting_default_browser_notification_text))
                 .setAutoCancel(false)
                 .setOngoing(true)
+                .setContentIntent(buildIntent())
                 .build();
 
         startForeground(FG_NOTIFICATION_ID, notification);
@@ -185,11 +186,12 @@ public class ComponentToggleService extends Service {
         // to post a new notification so people can go to SettingsActivity easily
         // this notification will be removed by SettingsActivity if it is in foreground
         final NotificationCompat.Builder builder =
-                NotificationUtil.importantBuilder(getApplicationContext(), buildIntent());
+                NotificationUtil.importantBuilder(getApplicationContext());
 
         final Notification notification = builder
                 .setContentTitle(getString(R.string.setting_default_browser_notification_clickable_text))
                 .setAutoCancel(true)
+                .setContentIntent(buildIntent())
                 .build();
 
         NotificationManagerCompat.from(getApplicationContext())

--- a/app/src/main/java/org/mozilla/focus/notification/NotificationUtil.java
+++ b/app/src/main/java/org/mozilla/focus/notification/NotificationUtil.java
@@ -7,7 +7,6 @@ package org.mozilla.focus.notification;
 
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
@@ -27,12 +26,11 @@ public class NotificationUtil {
      * @param context
      * @return
      */
-    public static NotificationCompat.Builder baseBuilder(Context context, PendingIntent pendingIntent) {
+    public static NotificationCompat.Builder baseBuilder(Context context) {
         final NotificationCompat.Builder builder = new NotificationCompat.Builder(context, DEFAULT_CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_notification)
                 .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), R.mipmap.ic_launcher))
                 .setColor(ContextCompat.getColor(context, R.color.surveyNotificationAccent))
-                .setContentIntent(pendingIntent)
                 .setAutoCancel(true);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -43,9 +41,9 @@ public class NotificationUtil {
     }
 
     // DEFAULT_VIBRATE makes notifications can show heads-up for Android 7 and below
-    public static NotificationCompat.Builder importantBuilder(Context context, PendingIntent pendingIntent) {
+    public static NotificationCompat.Builder importantBuilder(Context context) {
 
-        final NotificationCompat.Builder builder = baseBuilder(context, pendingIntent)
+        final NotificationCompat.Builder builder = baseBuilder(context)
                 .setDefaults(NotificationCompat.DEFAULT_VIBRATE)
                 .setPriority(NotificationCompat.PRIORITY_HIGH);
 

--- a/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.java
+++ b/app/src/main/java/org/mozilla/focus/notification/RocketMessagingService.java
@@ -33,7 +33,8 @@ public class RocketMessagingService extends FirebaseMessagingServiceWrapper {
         final PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent,
                 PendingIntent.FLAG_ONE_SHOT);
 
-        final NotificationCompat.Builder builder = NotificationUtil.importantBuilder(this, pendingIntent);
+        final NotificationCompat.Builder builder = NotificationUtil.importantBuilder(this)
+                .setContentIntent(pendingIntent);
 
         if (title != null) {
             builder.setContentTitle(title);

--- a/app/src/main/java/org/mozilla/focus/utils/DialogUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/DialogUtils.java
@@ -176,8 +176,9 @@ public class DialogUtils {
         final PendingIntent openRocketPending = PendingIntent.getBroadcast(context, REQUEST_RATE_CLICK, openRocket,
                 PendingIntent.FLAG_ONE_SHOT);
         final String string = context.getString(R.string.rate_app_dialog_text_title, context.getString(R.string.app_name)) + "\uD83D\uDE00";
-        final NotificationCompat.Builder builder = NotificationUtil.importantBuilder(context, openRocketPending)
-                .setContentText(string);
+        final NotificationCompat.Builder builder = NotificationUtil.importantBuilder(context)
+                .setContentText(string)
+                .setContentIntent(openRocketPending);
 
         // Send this intent in Broadcast receiver so we can cancel the notification there.
         // Build notification action for rate 5 stars
@@ -206,8 +207,9 @@ public class DialogUtils {
                 PendingIntent.FLAG_ONE_SHOT);
 
         final String title = context.getString(R.string.preference_default_browser) + "?\uD83D\uDE0A";
-        NotificationCompat.Builder builder = NotificationUtil.importantBuilder(context, openRocketPending)
-                .setContentTitle(title);
+        NotificationCompat.Builder builder = NotificationUtil.importantBuilder(context)
+                .setContentTitle(title)
+                .setContentIntent(openRocketPending);
 
         // Show notification
         NotificationUtil.sendNotification(context, NotificationId.DEFAULT_BROWSER, builder);
@@ -220,11 +222,12 @@ public class DialogUtils {
         final PendingIntent openRocketPending = PendingIntent.getBroadcast(context, REQUEST_PRIVACY_POLICY_CLICK, privacyPolicyUpdateNotice,
                 PendingIntent.FLAG_ONE_SHOT);
 
-        NotificationCompat.Builder builder = NotificationUtil.importantBuilder(context, openRocketPending)
+        NotificationCompat.Builder builder = NotificationUtil.importantBuilder(context)
                 .setContentTitle(context.getString(R.string.privacy_policy_update_notification_title))
                 .setContentText(context.getString(R.string.privacy_policy_update_notification_action))
                 .setStyle(new NotificationCompat.BigTextStyle()
-                        .bigText(context.getString(R.string.privacy_policy_update_notification_action)));
+                        .bigText(context.getString(R.string.privacy_policy_update_notification_action)))
+                .setContentIntent(openRocketPending);
 
         // Show notification
         NotificationUtil.sendNotification(context, NotificationId.PRIVACY_POLICY_UPDATE, builder);

--- a/app/src/main/java/org/mozilla/rocket/component/PrivateSessionNotificationService.kt
+++ b/app/src/main/java/org/mozilla/rocket/component/PrivateSessionNotificationService.kt
@@ -45,8 +45,9 @@ class PrivateSessionNotificationService : Service() {
 
     private fun showNotification() {
 
-        val builder = NotificationUtil.baseBuilder(applicationContext, buildIntent(true))
+        val builder = NotificationUtil.baseBuilder(applicationContext)
                 .setContentTitle(getString(R.string.private_browsing_erase_message))
+                .setContentIntent(buildIntent(true))
                 .addAction(R.drawable.private_browsing_mask, getString(R.string.private_browsing_open_action), buildIntent(false))
 
         startForeground(NotificationId.PRIVATE_MODE, builder.build())


### PR DESCRIPTION
(avoid passing pendingIntent to the method).
I feel like the method interface would make more sense.