### PR TITLE
privately: add container for fullscreen video

### DIFF
--- a/app/src/main/res/layout/fragment_private_browser.xml
+++ b/app/src/main/res/layout/fragment_private_browser.xml
@@ -71,7 +71,14 @@
 
         </org.mozilla.focus.widget.ResizableKeyboardLayout>
 
-        <include layout="@layout/fragment_private_browser_item_menu_button" />
-
     </FrameLayout>
+
+    <include layout="@layout/fragment_private_browser_item_menu_button" />
+
+    <FrameLayout
+        android:id="@+id/video_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/black"
+        android:visibility="gone" />
 </FrameLayout>


### PR DESCRIPTION
Port the fullscreen related implementation from BrowserFragment.java.
Currently we don't handle screen rotation since it will effect Fragment
re-creation.

to solve #2243