### PR TITLE
When close the app, we should also leave private mode

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/component/PrivateSessionNotificationService.kt
+++ b/app/src/main/java/org/mozilla/rocket/component/PrivateSessionNotificationService.kt
@@ -47,22 +47,32 @@ class PrivateSessionNotificationService : Service() {
 
         val builder = NotificationUtil.baseBuilder(applicationContext)
                 .setContentTitle(getString(R.string.private_browsing_erase_message))
-                .setContentIntent(buildIntent(true))
-                .addAction(R.drawable.private_browsing_mask, getString(R.string.private_browsing_open_action), buildIntent(false))
+                .setContentIntent(buildPendingIntent(true))
+                .addAction(R.drawable.private_browsing_mask, getString(R.string.private_browsing_open_action), buildPendingIntent(false))
 
         startForeground(NotificationId.PRIVATE_MODE, builder.build())
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        startActivity(buildIntent(true))
+        super.onTaskRemoved(rootIntent)
 
-    private fun buildIntent(sanitize: Boolean): PendingIntent {
-        val intent = Intent(applicationContext, PrivateModeActivity::class.java)
-        if (sanitize) {
-            intent.action = PrivateMode.INTENT_EXTRA_SANITIZE
-        }
+    }
+
+    private fun buildPendingIntent(sanitize: Boolean): PendingIntent {
+        val intent = buildIntent(sanitize)
         return PendingIntent.getActivity(applicationContext,
                 0,
                 intent,
                 PendingIntent.FLAG_UPDATE_CURRENT)
+    }
+
+    private fun buildIntent(sanitize: Boolean): Intent {
+        val intent = Intent(applicationContext, PrivateModeActivity::class.java)
+        if (sanitize) {
+            intent.action = PrivateMode.INTENT_EXTRA_SANITIZE
+        }
+        return intent
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
@@ -53,6 +53,7 @@ class PrivateModeActivity : LocaleAwareAppCompatActivity(),
 
     override fun onDestroy() {
         super.onDestroy()
+        stopPrivateMode()
         session?.destroy()
     }
 

--- a/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
@@ -8,6 +8,7 @@ package org.mozilla.rocket.privately
 import android.arch.lifecycle.ViewModelProviders
 import android.content.Intent
 import android.os.Bundle
+import android.support.annotation.CheckResult
 import android.support.v4.app.Fragment
 import android.view.View
 import android.widget.Toast
@@ -37,7 +38,10 @@ class PrivateModeActivity : LocaleAwareAppCompatActivity(),
 
         tabViewProvider = PrivateTabViewProvider(this)
 
-        handleIntent(intent)
+        val exitEarly = handleIntent(intent)
+        if (exitEarly) {
+            return
+        }
 
         setContentView(R.layout.activity_private_mode)
 
@@ -112,7 +116,12 @@ class PrivateModeActivity : LocaleAwareAppCompatActivity(),
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-        handleIntent(intent)
+
+        val exitEarly = handleIntent(intent)
+        if (exitEarly) {
+            return
+        }
+
 
     }
 
@@ -192,12 +201,15 @@ class PrivateModeActivity : LocaleAwareAppCompatActivity(),
         Toast.makeText(this, R.string.private_browsing_erase_done, Toast.LENGTH_LONG).show()
     }
 
-    private fun handleIntent(intent: Intent?) {
+    @CheckResult
+    private fun handleIntent(intent: Intent?): Boolean {
 
         if (intent?.action == PrivateMode.INTENT_EXTRA_SANITIZE) {
             stopPrivateMode()
             finishAndRemoveTask()
+            return true
         }
+        return false
     }
 
 


### PR DESCRIPTION
When the user swipes Rocket out in Recent Apps, the private mode should end. #2307 