### PR TITLE
privately: replace share button by delete button

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/FragmentListener.java
+++ b/app/src/main/java/org/mozilla/focus/widget/FragmentListener.java
@@ -25,6 +25,7 @@ public interface FragmentListener {
         UPDATE_MENU, // no payload
         REFRESH_TOP_SITE, // no payload
         TOGGLE_PRIVATE_MODE, // no payload
+        DROP_BROWSING_PAGES, // no payload
         SHOW_TAB_TRAY, // no payload
     }
 

--- a/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
@@ -73,6 +73,7 @@ class PrivateModeActivity : LocaleAwareAppCompatActivity(),
             TYPE.DISMISS_URL_INPUT -> dismissUrlInput()
             TYPE.OPEN_URL_IN_CURRENT_TAB -> openUrl(payload)
             TYPE.OPEN_URL_IN_NEW_TAB -> openUrl(payload)
+            TYPE.DROP_BROWSING_PAGES -> dropBrowserFragment()
             else -> {
             }
         }
@@ -99,8 +100,7 @@ class PrivateModeActivity : LocaleAwareAppCompatActivity(),
                         return
                     }
                 }
-                getNavController().navigateUp()
-                stopPrivateMode()
+                dropBrowserFragment()
             }
         }
     }
@@ -121,8 +121,11 @@ class PrivateModeActivity : LocaleAwareAppCompatActivity(),
         if (exitEarly) {
             return
         }
+    }
 
-
+    private fun dropBrowserFragment() {
+        getNavController().navigateUp()
+        stopPrivateMode()
     }
 
     private fun pushToBack() {

--- a/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragment.kt
@@ -99,7 +99,7 @@ class BrowserFragment : LocaleAwareFragment(),
         view.findViewById<View>(R.id.btn_mode).setOnClickListener { onModeClicked() }
         view.findViewById<View>(R.id.btn_search).setOnClickListener { onSearchClicked() }
         view.findViewById<View>(R.id.btn_refresh).setOnClickListener { onRefreshClicked() }
-        view.findViewById<View>(R.id.btn_share).setOnClickListener { onShareClicked() }
+        view.findViewById<View>(R.id.btn_delete).setOnClickListener { onDeleteClicked() }
 
         btnNext = (view.findViewById<View>(R.id.btn_next) as ImageButton)
                 .also {
@@ -211,19 +211,12 @@ class BrowserFragment : LocaleAwareFragment(),
         reload()
     }
 
-    private fun onShareClicked() {
-        val url = tabsSession.focusTab?.url ?: return
-        if (UrlUtils.isInternalErrorURL(url)) {
-            return
+    private fun onDeleteClicked() {
+        val listener = activity as FragmentListener
+        for (tab in tabsSession.tabs) {
+            tabsSession.dropTab(tab.id)
         }
-
-        Intent().also {
-            it.action = Intent.ACTION_SEND
-            it.type = "text/plain"
-            it.putExtra(Intent.EXTRA_TEXT, url)
-        }.let {
-            startActivity(Intent.createChooser(it, getString(R.string.share_dialog_title)))
-        }
+        listener.onNotified(BrowserFragment@ this, TYPE.DROP_BROWSING_PAGES, null)
     }
 
     class BrowserTabsChromeListener(val fragment: BrowserFragment) : DefaultTabsChromeListener() {

--- a/app/src/main/res/layout/fragment_private_browser_item_menu_button.xml
+++ b/app/src/main/res/layout/fragment_private_browser_item_menu_button.xml
@@ -45,10 +45,10 @@
             app:srcCompat="@drawable/ic_refresh" />
 
         <ImageButton
-            android:id="@+id/btn_share"
+            android:id="@+id/btn_delete"
             style="@style/MainMenuButton"
             android:tint="@color/private_menu_button"
-            app:srcCompat="@drawable/action_share" />
+            app:srcCompat="@drawable/ic_delete" />
 
     </org.mozilla.focus.widget.EqualDistributeRow>
 </FrameLayout>


### PR DESCRIPTION
Per designer's suggestion, to replace share button by delete button.
Click delete button will close tab and go back to privately-home-fragment.

to close #2224