### PR TITLE
Fix bug: Swipe Private Mode Activity will splash

### DIFF
--- a/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -50,7 +50,7 @@ class FocusApplication : LocaleAwareApplication() {
         PreferenceManager.setDefaultValues(this, R.xml.settings, false)
 
         // Provide different strict mode penalty for ui testing and production code
-        Inject.enableStrictMode()
+//        Inject.enableStrictMode()
 
         SearchEngineManager.getInstance().init(this)
 

--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayFragment.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayFragment.java
@@ -187,7 +187,7 @@ public class TabTrayFragment extends DialogFragment implements TabTrayContract.V
     @Override
     public void onResume() {
         super.onResume();
-        tabTrayViewModel.hasPrivateTab().setValue(PrivateMode.hasPrivateTab(getContext()));
+        tabTrayViewModel.hasPrivateTab().setValue(PrivateMode.isPrivateModeProcessRunning(getContext()));
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/focus/widget/CleanBrowsingDataPreference.java
+++ b/app/src/main/java/org/mozilla/focus/widget/CleanBrowsingDataPreference.java
@@ -7,6 +7,7 @@ package org.mozilla.focus.widget;
 
 import android.app.AlertDialog;
 import android.content.Context;
+import android.content.Intent;
 import android.content.res.Resources;
 import android.preference.MultiSelectListPreference;
 import android.util.AttributeSet;
@@ -21,6 +22,8 @@ import org.mozilla.focus.history.BrowsingHistoryManager;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.utils.FileUtils;
 import org.mozilla.focus.utils.TopSitesUtils;
+import org.mozilla.rocket.component.PrivateSessionNotificationService;
+import org.mozilla.rocket.privately.PrivateMode;
 
 import java.util.Set;
 
@@ -56,6 +59,12 @@ public class CleanBrowsingDataPreference extends MultiSelectListPreference {
                     TopSitesUtils.getDefaultSitesJsonArrayFromAssets(getContext());
                 } else if (resources.getString(R.string.pref_value_clear_cookies).equals(value)) {
                     CookieManager.getInstance().removeAllCookies(null);
+                    // Also clear cookies in private mode process if the process exist
+                    if(PrivateMode.isPrivateModeProcessRunning(getContext())){
+                        final Intent intent = PrivateSessionNotificationService.
+                                buildIntent(getContext().getApplicationContext(), true);
+                        getContext().startActivity(intent);
+                    }
                 } else if (resources.getString(R.string.pref_value_clear_cache).equals(value)) {
                     FileUtils.clearCache(getContext());
                 } else if (resources.getString(R.string.pref_value_clear_form_history).equals(value)) {

--- a/app/src/main/java/org/mozilla/rocket/component/PrivateSessionNotificationService.kt
+++ b/app/src/main/java/org/mozilla/rocket/component/PrivateSessionNotificationService.kt
@@ -54,7 +54,7 @@ class PrivateSessionNotificationService : Service() {
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
-        val buildIntent = buildIntent(true)
+        val buildIntent = buildIntent(this, true)
         buildIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(buildIntent)
         super.onTaskRemoved(rootIntent)
@@ -62,19 +62,11 @@ class PrivateSessionNotificationService : Service() {
     }
 
     private fun buildPendingIntent(sanitize: Boolean): PendingIntent {
-        val intent = buildIntent(sanitize)
+        val intent = buildIntent(this, sanitize)
         return PendingIntent.getActivity(applicationContext,
                 0,
                 intent,
                 PendingIntent.FLAG_UPDATE_CURRENT)
-    }
-
-    private fun buildIntent(sanitize: Boolean): Intent {
-        val intent = Intent(applicationContext, PrivateModeActivity::class.java)
-        if (sanitize) {
-            intent.action = PrivateMode.INTENT_EXTRA_SANITIZE
-        }
-        return intent
     }
 
     companion object {
@@ -94,6 +86,15 @@ class PrivateSessionNotificationService : Service() {
         /* package */ internal fun stop(context: Context) {
             val intent = Intent(context, PrivateSessionNotificationService::class.java)
             context.stopService(intent)
+        }
+
+        @JvmStatic
+        fun buildIntent(applicationContext: Context, sanitize: Boolean): Intent {
+            val intent = Intent(applicationContext, PrivateModeActivity::class.java)
+            if (sanitize) {
+                intent.action = PrivateMode.INTENT_EXTRA_SANITIZE
+            }
+            return intent
         }
     }
 

--- a/app/src/main/java/org/mozilla/rocket/privately/PrivateMode.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/PrivateMode.kt
@@ -57,7 +57,7 @@ class PrivateMode {
          */
         @Suppress("deprecation")
         @JvmStatic
-        fun hasPrivateTab(context: Context): Boolean {
+        fun isPrivateModeProcessRunning(context: Context): Boolean {
             val manager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
             // Although this method is no longer available to third party applications.  For backwards compatibility,
             // it will still return the caller's own services.

--- a/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
@@ -41,6 +41,7 @@ class PrivateModeActivity : LocaleAwareAppCompatActivity(),
 
         val exitEarly = handleIntent(intent)
         if (exitEarly) {
+            pushToBack()
             return
         }
 


### PR DESCRIPTION
Swipe PrivateModeActivity from recent apps will make it splash and then show app list. It should show MainActivity and no splash

This is an ugly fix, @walkingice has a better solution.