### PR TITLE
tabs: make TabViewProvider.purify as a static method

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -1018,7 +1018,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
     }
 
     // a TabViewProvider and it should only be used in this activity
-    private static class MainTabViewProvider implements TabViewProvider {
+    private static class MainTabViewProvider extends TabViewProvider {
         private Activity activity;
 
         MainTabViewProvider(@NonNull final Activity activity) {
@@ -1031,11 +1031,6 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Fragme
             // TabView and View is totally different, we know WebViewProvider returns a TabView for now,
             // but there is no promise about this.
             return (TabView) WebViewProvider.create(this.activity, null);
-        }
-
-        @Override
-        public void purify() {
-            // per current requirement, we do not need purify in normal-mode-browsing.
         }
     }
 }

--- a/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
@@ -23,6 +23,7 @@ import org.mozilla.focus.widget.BackKeyHandleable
 import org.mozilla.focus.widget.FragmentListener
 import org.mozilla.focus.widget.FragmentListener.TYPE
 import org.mozilla.rocket.component.PrivateSessionNotificationService
+import org.mozilla.rocket.tabs.TabViewProvider
 import org.mozilla.rocket.tabs.TabsSession
 import org.mozilla.rocket.tabs.TabsSessionProvider
 
@@ -202,7 +203,7 @@ class PrivateModeActivity : LocaleAwareAppCompatActivity(),
     private fun stopPrivateMode() {
         PrivateSessionNotificationService.stop(this)
         PrivateMode.sanitize(this.applicationContext)
-        tabViewProvider.purify()
+        TabViewProvider.purify(this)
         Toast.makeText(this, R.string.private_browsing_erase_done, Toast.LENGTH_LONG).show()
     }
 

--- a/app/src/main/java/org/mozilla/rocket/privately/PrivateTabViewProvider.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/PrivateTabViewProvider.kt
@@ -6,14 +6,10 @@ import org.mozilla.focus.web.WebViewProvider
 import org.mozilla.rocket.tabs.TabView
 import org.mozilla.rocket.tabs.TabViewProvider
 
-class PrivateTabViewProvider(private val host: Activity) : TabViewProvider {
+class PrivateTabViewProvider(private val host: Activity) : TabViewProvider() {
 
     override fun create(): TabView {
         return WebViewProvider.create(host, null, WebViewSettingsHook) as TabView
-    }
-
-    override fun purify() {
-        create().cleanup()
     }
 
     object WebViewSettingsHook : WebViewProvider.WebSettingsHook {

--- a/app/src/test/java/org/mozilla/focus/tabs/tabtray/TabTrayPresenterTest.kt
+++ b/app/src/test/java/org/mozilla/focus/tabs/tabtray/TabTrayPresenterTest.kt
@@ -92,13 +92,10 @@ class TabTrayPresenterTest {
         Assert.assertEquals(4, tabListCaptor.value.size)
     }
 
-    private class DefaultTabViewProvider : TabViewProvider {
+    private class DefaultTabViewProvider : TabViewProvider() {
 
         override fun create(): TabView {
             return DefaultTabView()
-        }
-
-        override fun purify() {
         }
     }
 

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewProvider.java
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewProvider.java
@@ -5,17 +5,30 @@
 
 package org.mozilla.rocket.tabs;
 
+import android.content.Context;
+import android.webkit.CookieManager;
+import android.webkit.WebStorage;
+import android.webkit.WebViewDatabase;
+
 /**
  * A class to create TabView instance.
  */
-public interface TabViewProvider {
-    TabView create();
+public abstract class TabViewProvider {
+    public abstract TabView create();
 
     /**
      * To clean up some persistent data which effect provided TabView, but not directly inside the TabView.
      * <p>
      * For instance, a cookie effect a @see{android.webkit.WebView} but it is stores in another place.
-     * A TabViewProvider knows its real implementation, and this is the interface for caller to clean up.
+     * This method might be invoked at any time, any place. Therefore it is static method.
+     * Current the only one TabView implementation is for Webkit based WebView, so it is ok for now.
+     * TODO: If we have more implementation, rewrite this.
      */
-    void purify();
+    public static void purify(final Context context) {
+        CookieManager.getInstance().removeAllCookies(null);
+        WebStorage.getInstance().deleteAllData();
+        final WebViewDatabase webViewDatabase = WebViewDatabase.getInstance(context);
+        webViewDatabase.clearFormData();
+        webViewDatabase.clearHttpAuthUsernamePassword();
+    }
 }

--- a/components/feature/tabs/src/test/java/org/mozilla/rocket/tabs/TabsSessionTest.java
+++ b/components/feature/tabs/src/test/java/org/mozilla/rocket/tabs/TabsSessionTest.java
@@ -361,8 +361,7 @@ public class TabsSessionTest {
         Assert.assertNull(session.getFocusTab());
     }
 
-    private static class DefaultTabViewProvider implements TabViewProvider {
-
+    private static class DefaultTabViewProvider extends TabViewProvider {
         @Override
         public TabView create() {
             return new DefaultTabView();


### PR DESCRIPTION
In current requirement, the method `purify` might be invoked at any
time, any place. For example, a Service to invoke this to ensure user
logged-out. It means, not only Activity needs this method.

We got a problem: We want more TabViewProvider implementation (for
WebkitView, GeckoView...), and each implementation has its own logic to
do `purify`. How can we abstract this, but without making things too
complicate? We have no idea.

Before we adopt second TabView implentation, let's keep it simple for
now, and cross our fingers.