### PR TITLE
Add pref to enable Private Mode at debug/firebase build type.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -42,6 +42,11 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         super.onCreate(savedInstanceState);
 
         addPreferencesFromResource(R.xml.settings);
+        if (AppConstants.isReleaseBuild() || AppConstants.isBetaBuild()) {
+            PreferenceScreen rootPreferences = (PreferenceScreen) findPreference(PREF_KEY_ROOT);
+            Preference prefPrivateMode = findPreference(PrivateMode.PREF_KEY_PRIVATE_MODE_ENABLED);
+            rootPreferences.removePreference(prefPrivateMode);
+        }
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/rocket/privately/PrivateMode.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/PrivateMode.kt
@@ -9,8 +9,8 @@ import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import android.preference.PreferenceManager
 import org.mozilla.focus.utils.AppConfigWrapper
+import org.mozilla.focus.utils.AppConstants
 import org.mozilla.focus.utils.FileUtils
-import org.mozilla.focus.utils.FirebaseHelper
 import org.mozilla.focus.utils.ThreadUtils
 import org.mozilla.rocket.component.PrivateSessionNotificationService
 import java.io.File
@@ -21,6 +21,7 @@ class PrivateMode {
 
     // Provide common resources, and helper functions
     companion object {
+        const val PREF_KEY_PRIVATE_MODE_ENABLED = "pref_key_private_mode_enabled"
         const val PREF_KEY_SANITIZE_REMINDER = "pref_key_sanitize_reminder"
 
         const val INTENT_EXTRA_SANITIZE = "intent_extra_sanitize"
@@ -31,7 +32,12 @@ class PrivateMode {
         // The option to enable it is on Nightly. The logic is in SettingsFragment.
         @JvmStatic
         fun isEnable(context: Context): Boolean {
-            return AppConfigWrapper.isPrivateModeEnabled(context);
+            // We look at Firebase Remote Config if in Release and Beta build type
+            if (AppConstants.isReleaseBuild() || AppConstants.isBetaBuild()) {
+                return AppConfigWrapper.isPrivateModeEnabled(context);
+            }
+            // In Debug and Firebase(debug) build type, enable Private Mode by default
+            return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(PREF_KEY_PRIVATE_MODE_ENABLED, true)
         }
 
         @JvmStatic

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -66,4 +66,10 @@
         android:title="@string/menu_about"
         android:key="@string/pref_key_about" />
 
+    <CheckBoxPreference
+        android:contentDescription="You should only see this under Debug and Firebase build type"
+        android:defaultValue="true"
+        android:key="pref_key_private_mode_enabled"
+        android:title="Enable Private Mode" />
+
 </PreferenceScreen>

--- a/app/src/test/java/org/mozilla/rocket/privately/PrivateModeTest.kt
+++ b/app/src/test/java/org/mozilla/rocket/privately/PrivateModeTest.kt
@@ -4,12 +4,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.rocket.privately
 
-import android.preference.PreferenceManager
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.focus.utils.AppConfigWrapper
+import org.mozilla.focus.utils.AppConstants
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
@@ -18,7 +16,11 @@ import org.robolectric.RuntimeEnvironment
 class PrivateModeTest {
 
     @Test
-    fun `Private mode is default off`() {
-        assertFalse(PrivateMode.isEnable(RuntimeEnvironment.application))
+    fun `Private mode is default off in Release and Beta build type and is default on in Firebase and Debug build type`() {
+        if (AppConstants.isReleaseBuild() || AppConstants.isBetaBuild()) {
+            Assert.assertFalse(PrivateMode.isEnable(RuntimeEnvironment.application))
+        } else {
+            Assert.assertTrue(PrivateMode.isEnable(RuntimeEnvironment.application))
+        }
     }
 }


### PR DESCRIPTION
As a developer, I'd like work on Private Mode even if Firebase Remote
Config turn it off. This patch give the option back to developer in
non-beta/non-release channel
.
tested in release and debug build type.