### PR TITLE
Fix TakeScreenshotTest break issue.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/Inject.java
+++ b/app/src/androidTest/java/org/mozilla/focus/Inject.java
@@ -82,4 +82,7 @@ public class Inject {
         // Do nothing in testing
     }
 
+    public static boolean isUnderEspressoTest() {
+        return true;
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/TakeScreenshotTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/TakeScreenshotTest.kt
@@ -5,19 +5,29 @@
 
 package org.mozilla.focus.activity
 
+import android.Manifest
 import android.support.annotation.Keep
+import android.support.test.rule.GrantPermissionRule
 import android.support.test.runner.AndroidJUnit4
 import org.junit.Before
 import org.junit.Ignore
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.autobot.session
 import org.mozilla.focus.utils.AndroidTestUtils
 
 @Keep
-@Ignore
 @RunWith(AndroidJUnit4::class)
 class TakeScreenshotTest {
+
+    @JvmField
+    @Rule
+    val writePermissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+
+    @JvmField
+    @Rule
+    val readPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE)
 
     @Before
     fun setUp() {

--- a/app/src/androidTest/java/org/mozilla/focus/autobot/Autobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/autobot/Autobot.kt
@@ -49,15 +49,9 @@ inline fun runWithIdleRes(ir: IdlingResource?, pendingCheck: () -> Unit) {
 
 
 class SessionRobot {
+
     @Rule
     val activityTestRule = ActivityTestRule(MainActivity::class.java, true, false)
-
-    @Rule
-    val writePermissionRule = GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-
-    @Rule
-    val readPermissionRule = GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE)
-
 
     private var sessionLoadedIdlingResource: SessionLoadedIdlingResource? = null
 
@@ -91,7 +85,6 @@ class SessionRobot {
 class ScreenshotRobot(val activityTestRule: ActivityTestRule<MainActivity>) {
 
     private var screenshotIdlingResource: ScreenshotIdlingResource? = null
-
 
     fun takeScreenshot(): ScreenshotRobot {
         screenshotIdlingResource = ScreenshotIdlingResource(activityTestRule.getActivity())

--- a/app/src/main/java/org/mozilla/focus/Inject.java
+++ b/app/src/main/java/org/mozilla/focus/Inject.java
@@ -71,4 +71,8 @@ public class Inject {
     public static void setActivityNewlyCreatedFlag() {
         sIsNewCreated = false;
     }
+
+    public static boolean isUnderEspressoTest() {
+        return false;
+    }
 }

--- a/app/src/main/java/org/mozilla/focus/fragment/ScreenCaptureDialogFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/ScreenCaptureDialogFragment.java
@@ -22,6 +22,7 @@ import com.airbnb.lottie.LottieAnimationView;
 import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.OnCompositionLoadedListener;
 
+import org.mozilla.focus.Inject;
 import org.mozilla.focus.R;
 
 public class ScreenCaptureDialogFragment extends DialogFragment {
@@ -57,6 +58,11 @@ public class ScreenCaptureDialogFragment extends DialogFragment {
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.dialog_capture_screen, container, false);
         mLottieAnimationView = (LottieAnimationView) view.findViewById(R.id.animation_view);
+        if (!Inject.isUnderEspressoTest()) {
+            // Since Lottie 2.5.0, infinite animation may affect ScreenshotCaptureTask to be finished on bitrise.
+            // We don't play animation during testing
+            mLottieAnimationView.playAnimation();
+        }
         return view;
     }
 

--- a/app/src/main/java/org/mozilla/focus/screenshot/CaptureRunnable.java
+++ b/app/src/main/java/org/mozilla/focus/screenshot/CaptureRunnable.java
@@ -7,6 +7,7 @@ import android.text.TextUtils;
 import android.view.View;
 import android.widget.Toast;
 
+import org.mozilla.focus.Inject;
 import org.mozilla.focus.R;
 import org.mozilla.focus.fragment.BrowserFragment;
 import org.mozilla.focus.fragment.ScreenCaptureDialogFragment;
@@ -82,7 +83,7 @@ public class CaptureRunnable extends ScreenshotCaptureTask implements Runnable, 
         if (TextUtils.isEmpty(path)) {
             screenCaptureDialogFragment.dismiss();
         } else {
-            screenCaptureDialogFragment.dismiss(true);
+            screenCaptureDialogFragment.dismiss(!Inject.isUnderEspressoTest());
         }
     }
 

--- a/app/src/main/res/layout/dialog_capture_screen.xml
+++ b/app/src/main/res/layout/dialog_capture_screen.xml
@@ -19,7 +19,6 @@
         android:layout_centerHorizontal="true"
         android:layout_width="85dp"
         android:layout_height="85dp"
-        app:lottie_autoPlay="true"
         app:lottie_fileName="screenshots-loading.json"
         app:lottie_loop="true" />
 


### PR DESCRIPTION
- Test is failed when Lottie is updated from 2.2.0 to 2.5.5. We can observe the break since 2.5.0+.
- During TakeScreenshotTest is running, screen capture animation won't be played when Lottie version is less than 2.5.0 but is played on 2.5.0+.
- Test failed only happens on Bitrise and cannot reproduce locally.
- If the animation is played, TakeScreenshotTest will be stuck in:
https://github.com/mozilla-tw/Rocket/blob/37e309e79a0fbf711fe9a48e8f7c1cfad9dcf1da/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotCaptureTask.java#L70-L71