### PR TITLE
Fix NavigationTest and BrowsingIntentTest flaky issue.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/BrowsingIntentTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/BrowsingIntentTest.java
@@ -140,6 +140,7 @@ public class BrowsingIntentTest {
         Intent intent = new Intent();
         intent.setAction(Intent.ACTION_VIEW);
         intent.setData(Uri.parse(TARGET_URL_SITE_1));
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         final Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         intent.setPackage(targetContext.getPackageName());
         targetContext.startActivity(intent);


### PR DESCRIPTION
Fix test break in build:
https://app.bitrise.io/build/78680edaa48a299a
- BrowsingIntentTest:
android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. 
- NavigationTest
The symptom is calling Espresso.pressBack() will go back to HomeFragment instead of previous web page while web view did have back stack. Looks like some transaction is not ready once we call pressBack immediately when the web page is loaded. To avoid this case, we add some actions(swipe up and swipe down)  to simulate browsing the web page once the page is loaded, then call pressBack().