### PR TITLE
Lazily initialize screenshot categories 

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/telemetry/TelemetryWrapperTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/telemetry/TelemetryWrapperTest.kt
@@ -322,7 +322,7 @@ class TelemetryWrapperTest {
     @Test
     fun clickToolbarCapture() {
         val sm = ScreenshotManager()
-        sm.initScreenShotCateogry(InstrumentationRegistry.getInstrumentation().targetContext)
+        sm.lazyInitCategories(InstrumentationRegistry.getInstrumentation().targetContext)
         sm.categories.values.forEach {
             TelemetryWrapper.clickToolbarCapture(it)
         }
@@ -475,7 +475,7 @@ class TelemetryWrapperTest {
     @Test
     fun openCaptureLink() {
         val sm = ScreenshotManager()
-        sm.initScreenShotCateogry(InstrumentationRegistry.getInstrumentation().targetContext)
+        sm.lazyInitCategories(InstrumentationRegistry.getInstrumentation().targetContext)
         sm.categories.values.forEach {
             TelemetryWrapper.openCaptureLink(it)
         }
@@ -484,7 +484,7 @@ class TelemetryWrapperTest {
     @Test
     fun editCaptureImage() {
         val sm = ScreenshotManager()
-        sm.initScreenShotCateogry(InstrumentationRegistry.getInstrumentation().targetContext)
+        sm.lazyInitCategories(InstrumentationRegistry.getInstrumentation().targetContext)
         sm.categories.values.forEach {
             TelemetryWrapper.editCaptureImage(true, it)
             TelemetryWrapper.editCaptureImage(false, it)
@@ -494,7 +494,7 @@ class TelemetryWrapperTest {
     @Test
     fun shareCaptureImage() {
         val sm = ScreenshotManager()
-        sm.initScreenShotCateogry(InstrumentationRegistry.getInstrumentation().targetContext)
+        sm.lazyInitCategories(InstrumentationRegistry.getInstrumentation().targetContext)
         sm.categories.values.forEach {
             TelemetryWrapper.shareCaptureImage(true, it)
             TelemetryWrapper.shareCaptureImage(false, it)
@@ -504,7 +504,7 @@ class TelemetryWrapperTest {
     @Test
     fun showCaptureInfo() {
         val sm = ScreenshotManager()
-        sm.initScreenShotCateogry(InstrumentationRegistry.getInstrumentation().targetContext)
+        sm.lazyInitCategories(InstrumentationRegistry.getInstrumentation().targetContext)
         sm.categories.values.forEach {
             TelemetryWrapper.showCaptureInfo(it)
         }
@@ -513,7 +513,7 @@ class TelemetryWrapperTest {
     @Test
     fun deleteCaptureImage() {
         val sm = ScreenshotManager()
-        sm.initScreenShotCateogry(InstrumentationRegistry.getInstrumentation().targetContext)
+        sm.lazyInitCategories(InstrumentationRegistry.getInstrumentation().targetContext)
         sm.categories.values.forEach {
             TelemetryWrapper.deleteCaptureImage(it)
         }

--- a/app/src/androidTest/java/org/mozilla/focus/telemetry/TelemetryWrapperTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/telemetry/TelemetryWrapperTest.kt
@@ -1,5 +1,6 @@
 package org.mozilla.focus.telemetry
 
+import android.content.Context
 import android.preference.PreferenceManager
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
@@ -25,9 +26,10 @@ import org.mozilla.focus.telemetry.TelemetryWrapper.Value.VIDEO
 @RunWith(AndroidJUnit4::class)
 class TelemetryWrapperTest {
 
+    lateinit var context: Context
     @Before
     fun setUp() {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        context = InstrumentationRegistry.getInstrumentation().targetContext
         val prefName = context.getString(R.string.pref_key_telemetry)
         val preferences = PreferenceManager.getDefaultSharedPreferences(context)
         preferences.edit().putBoolean(prefName, false).apply()
@@ -322,8 +324,7 @@ class TelemetryWrapperTest {
     @Test
     fun clickToolbarCapture() {
         val sm = ScreenshotManager()
-        sm.lazyInitCategories(InstrumentationRegistry.getInstrumentation().targetContext)
-        sm.categories.values.forEach {
+        sm.getCategories(context).values.forEach {
             TelemetryWrapper.clickToolbarCapture(it)
         }
     }
@@ -475,8 +476,7 @@ class TelemetryWrapperTest {
     @Test
     fun openCaptureLink() {
         val sm = ScreenshotManager()
-        sm.lazyInitCategories(InstrumentationRegistry.getInstrumentation().targetContext)
-        sm.categories.values.forEach {
+        sm.getCategories(context).values.forEach {
             TelemetryWrapper.openCaptureLink(it)
         }
     }
@@ -484,8 +484,7 @@ class TelemetryWrapperTest {
     @Test
     fun editCaptureImage() {
         val sm = ScreenshotManager()
-        sm.lazyInitCategories(InstrumentationRegistry.getInstrumentation().targetContext)
-        sm.categories.values.forEach {
+        sm.getCategories(context).values.forEach {
             TelemetryWrapper.editCaptureImage(true, it)
             TelemetryWrapper.editCaptureImage(false, it)
         }
@@ -494,8 +493,7 @@ class TelemetryWrapperTest {
     @Test
     fun shareCaptureImage() {
         val sm = ScreenshotManager()
-        sm.lazyInitCategories(InstrumentationRegistry.getInstrumentation().targetContext)
-        sm.categories.values.forEach {
+        sm.getCategories(context).values.forEach {
             TelemetryWrapper.shareCaptureImage(true, it)
             TelemetryWrapper.shareCaptureImage(false, it)
         }
@@ -504,8 +502,7 @@ class TelemetryWrapperTest {
     @Test
     fun showCaptureInfo() {
         val sm = ScreenshotManager()
-        sm.lazyInitCategories(InstrumentationRegistry.getInstrumentation().targetContext)
-        sm.categories.values.forEach {
+        sm.getCategories(context).values.forEach {
             TelemetryWrapper.showCaptureInfo(it)
         }
     }
@@ -513,8 +510,7 @@ class TelemetryWrapperTest {
     @Test
     fun deleteCaptureImage() {
         val sm = ScreenshotManager()
-        sm.lazyInitCategories(InstrumentationRegistry.getInstrumentation().targetContext)
-        sm.categories.values.forEach {
+        sm.getCategories(context).values.forEach {
             TelemetryWrapper.deleteCaptureImage(it)
         }
     }

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -809,7 +809,7 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
                 break;
             case R.id.btn_capture:
                 onCaptureClicked();
-                TelemetryWrapper.clickToolbarCapture(ScreenshotManager.getInstance().getCategory(getUrl()));
+                // move Telemetry to ScreenCaptureTask doInBackground() cause we need to init category first.
                 break;
             default:
                 throw new IllegalArgumentException("Unhandled menu item in BrowserFragment");

--- a/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotCaptureTask.java
+++ b/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotCaptureTask.java
@@ -12,6 +12,7 @@ import android.text.TextUtils;
 
 import org.mozilla.focus.screenshot.model.Screenshot;
 import org.mozilla.focus.utils.DimenUtils;
+import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.utils.FileUtils;
 import org.mozilla.focus.utils.StorageUtils;
 
@@ -44,8 +45,12 @@ public class ScreenshotCaptureTask extends AsyncTask<Object, Void, String> {
             if (!TextUtils.isEmpty(path)) {
                 FileUtils.notifyMediaScanner(context, path);
 
+                ScreenshotManager.getInstance().lazyInitCategories(context);
                 Screenshot screenshot = new Screenshot(title, url, timestamp, path);
                 ScreenshotManager.getInstance().insert(screenshot, null);
+
+                TelemetryWrapper.clickToolbarCapture(ScreenshotManager.getInstance().getCategory(url));
+
             }
 
             return path;

--- a/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotCaptureTask.java
+++ b/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotCaptureTask.java
@@ -45,11 +45,10 @@ public class ScreenshotCaptureTask extends AsyncTask<Object, Void, String> {
             if (!TextUtils.isEmpty(path)) {
                 FileUtils.notifyMediaScanner(context, path);
 
-                ScreenshotManager.getInstance().lazyInitCategories(context);
                 Screenshot screenshot = new Screenshot(title, url, timestamp, path);
                 ScreenshotManager.getInstance().insert(screenshot, null);
 
-                TelemetryWrapper.clickToolbarCapture(ScreenshotManager.getInstance().getCategory(url));
+                TelemetryWrapper.clickToolbarCapture(ScreenshotManager.getInstance().getCategory(context, url));
 
             }
 

--- a/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotManager.java
+++ b/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotManager.java
@@ -75,9 +75,8 @@ public class ScreenshotManager {
         mQueryHandler.startQuery(QueryHandler.SCREENSHOT_TOKEN, listener, Uri.parse(Screenshot.CONTENT_URI.toString() + "?offset=" + offset + "&limit=" + limit), null, null, null, Screenshot.TIMESTAMP + " DESC");
     }
 
-    @VisibleForTesting
     @WorkerThread
-    public void lazyInitCategories(Context context) {
+    private void lazyInitCategories(Context context) {
         try {
             if (categories.size() != 0) {
                 return;
@@ -105,7 +104,10 @@ public class ScreenshotManager {
         }
     }
 
-    public String getCategory(String url) {
+    public String getCategory(Context context, String url) {
+
+        lazyInitCategories(context);
+
         try {
             // if category is not ready, return empty string
             if (categories.size() == 0) {
@@ -126,7 +128,10 @@ public class ScreenshotManager {
     }
 
     @VisibleForTesting
-    public HashMap<String, String> getCategories() {
+    public HashMap<String, String> getCategories(Context context) {
+
+        lazyInitCategories(context);
+
         return categories;
     }
 }

--- a/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotViewerActivity.java
+++ b/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotViewerActivity.java
@@ -489,6 +489,15 @@ public class ScreenshotViewerActivity extends LocaleAwareAppCompatActivity imple
 
         @Override
         protected Void doInBackground(Void... voids) {
+            final ScreenshotViewerActivity activity = activityRef.get();
+            if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
+                return null;
+            }
+            // initialize screenshot only when we need it.
+            ScreenshotManager.getInstance().lazyInitCategories(activity);
+            // set the category for later use
+            screenshot.setCategory(ScreenshotManager.getInstance().getCategory(screenshot.getUrl()));
+
             final File imgFile = new File(screenshot.getImageUri());
             if (imgFile.exists()) {
                 BitmapFactory.Options options = new BitmapFactory.Options();
@@ -519,7 +528,8 @@ public class ScreenshotViewerActivity extends LocaleAwareAppCompatActivity imple
             infoItems.get(1).title = activity.getString(R.string.screenshot_image_viewer_dialog_info_resolution1, String.format(Locale.getDefault(), "%dx%d", width, height));
             infoItems.get(2).title = activity.getString(R.string.screenshot_image_viewer_dialog_info_size1, fileSizeText);
             infoItems.get(3).title = activity.getString(R.string.screenshot_image_viewer_dialog_info_title1, screenshot.getTitle());
-            infoItems.get(4).title = activity.getString(R.string.screenshot_image_viewer_dialog_info_category, ScreenshotManager.getInstance().getCategory(screenshot.getUrl()));
+            // UX allow empty string if screenshot is not ready. But this shouldn't happen here.
+            infoItems.get(4).title = activity.getString(R.string.screenshot_image_viewer_dialog_info_category, screenshot.getCategory());
             infoItems.get(5).title = activity.getString(R.string.screenshot_image_viewer_dialog_info_url1, screenshot.getUrl());
 
             if (imageSource != null) {

--- a/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotViewerActivity.java
+++ b/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotViewerActivity.java
@@ -493,10 +493,8 @@ public class ScreenshotViewerActivity extends LocaleAwareAppCompatActivity imple
             if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
                 return null;
             }
-            // initialize screenshot only when we need it.
-            ScreenshotManager.getInstance().lazyInitCategories(activity);
             // set the category for later use
-            screenshot.setCategory(ScreenshotManager.getInstance().getCategory(screenshot.getUrl()));
+            screenshot.setCategory(ScreenshotManager.getInstance().getCategory(activity, screenshot.getUrl()));
 
             final File imgFile = new File(screenshot.getImageUri());
             if (imgFile.exists()) {

--- a/app/src/main/java/org/mozilla/focus/screenshot/model/Screenshot.java
+++ b/app/src/main/java/org/mozilla/focus/screenshot/model/Screenshot.java
@@ -5,7 +5,7 @@
 
 package org.mozilla.focus.screenshot.model;
 
-import org.mozilla.focus.screenshot.ScreenshotManager;
+import android.support.annotation.WorkerThread;
 
 import java.io.Serializable;
 
@@ -19,6 +19,7 @@ public class Screenshot implements Serializable {
     private String url;
     private long timestamp;
     private String imageUri;
+    private String category = "";
 
     public Screenshot() {
     }
@@ -70,8 +71,14 @@ public class Screenshot implements Serializable {
         this.imageUri = imageUri;
     }
 
+    // category is only set in a background thread since it's loading should be async.
+    @WorkerThread
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
     public String getCategory() {
-        return ScreenshotManager.getInstance().getCategory(this.url);
+        return category;
     }
 
     @Override

--- a/app/src/test/java/org/mozilla/focus/screenshot/ScreenshotManagerTest.kt
+++ b/app/src/test/java/org/mozilla/focus/screenshot/ScreenshotManagerTest.kt
@@ -2,7 +2,6 @@ package org.mozilla.focus.screenshot
 
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
@@ -12,7 +11,7 @@ class ScreenshotManagerTest {
     @Test
     fun testInit() {
         val sm = ScreenshotManager()
-        sm.initScreenShotCateogry(RuntimeEnvironment.application)
+        sm.lazyInitCategories(RuntimeEnvironment.application)
         assert(sm.categories.size > 0)
     }
 

--- a/app/src/test/java/org/mozilla/focus/screenshot/ScreenshotManagerTest.kt
+++ b/app/src/test/java/org/mozilla/focus/screenshot/ScreenshotManagerTest.kt
@@ -9,21 +9,14 @@ import org.robolectric.RuntimeEnvironment
 class ScreenshotManagerTest {
 
     @Test
-    fun testInit() {
-        val sm = ScreenshotManager()
-        sm.lazyInitCategories(RuntimeEnvironment.application)
-        assert(sm.categories.size > 0)
-    }
-
-    @Test
     fun testCategories() {
         val sm = ScreenshotManager()
-        sm.initScreenShotCateogry(RuntimeEnvironment.application)
-        assert(sm.getCategory("https://alipay.com/").equals("Banking"))
-        assert(sm.getCategory("https://m.alipay.com/").equals("Banking"))
+        val context = RuntimeEnvironment.application
+        assert(sm.getCategory(context, "https://alipay.com/").equals("Banking"))
+        assert(sm.getCategory(context, "https://m.alipay.com/").equals("Banking"))
 
-        assert(sm.getCategory("https://blogspot.com/").equals("Weblogs"))
-        assert(sm.getCategory("https://m.blogspot.com/").equals("Weblogs"))
+        assert(sm.getCategory(context, "https://blogspot.com/").equals("Weblogs"))
+        assert(sm.getCategory(context, "https://m.blogspot.com/").equals("Weblogs"))
 
     }
 }


### PR DESCRIPTION
Only initialize screenshot categories if we want to use it.

I haven't request for a review. Cause I'm thinking, can I do better?
There are two scnarios we need cat-init work.

1. When the user takes the screenshot.
2. When the user click a screenshot item and view the info

1. Is done. 
For 2, I now do the cat-init in bg work where we want to load the screenshot from disk.

I'm looking for a nicer solution:
For example, put the category init/matching work after onQueryComplete.
But [onQueryComplete()](https://github.com/commaai/android_frameworks_base/blob/master/core/java/android/content/AsyncQueryHandler.java#L344)) is called in its [caller thread](https://github.com/mozilla-tw/Rocket/blob/50524f36790b0d035e3a9f2632792ad76eef2bdc/app/src/main/java/org/mozilla/focus/screenshot/ScreenshotManager.java#L76).
I'll need to make the flow like this
UI(onQueryComplete)->BG(handle  category-init) -> UI (Update ScreenshotItemAdapter)

@mxlius @walkingice How do you think?

