### PR TITLE
pref: add Development category to preference

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -42,10 +42,10 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         super.onCreate(savedInstanceState);
 
         addPreferencesFromResource(R.xml.settings);
-        if (AppConstants.isReleaseBuild() || AppConstants.isBetaBuild()) {
+        if (!AppConstants.isDevBuild() && !AppConstants.isFirebaseBuild()) {
             PreferenceScreen rootPreferences = (PreferenceScreen) findPreference(PREF_KEY_ROOT);
-            Preference prefPrivateMode = findPreference(PrivateMode.PREF_KEY_PRIVATE_MODE_ENABLED);
-            rootPreferences.removePreference(prefPrivateMode);
+            Preference category = findPreference(getString(R.string.pref_key_category_development));
+            rootPreferences.removePreference(category);
         }
     }
 

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -31,6 +31,8 @@
 
     <string name="pref_key_focus_tab_id" translatable="false"><xliff:g id="preference_key">pref_key_focus_tab_id</xliff:g></string>
 
+    <string name="pref_key_category_development" translatable="false"><xliff:g id="preference_key">pref_key_category_development</xliff:g></string>
+
     <!-- data saving -->
     <string name="pref_key_data_saving_block_ads" translatable="false"><xliff:g id="preference_key">pref_data_saving_block_ads</xliff:g></string>
     <string name="pref_key_data_saving_block_webfonts" translatable="false"><xliff:g id="preference_key">pref_data_saving_block_webfonts</xliff:g></string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -66,10 +66,14 @@
         android:title="@string/menu_about"
         android:key="@string/pref_key_about" />
 
-    <CheckBoxPreference
-        android:contentDescription="You should only see this under Debug and Firebase build type"
-        android:defaultValue="true"
-        android:key="pref_key_private_mode_enabled"
-        android:title="Enable Private Mode" />
+    <!-- Preferences for development purpose, only visible in dev-build -->
+    <PreferenceCategory
+        android:key="@string/pref_key_category_development"
+        android:title="For Development">
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="pref_key_private_mode_enabled"
+            android:title="Private Mode" />
+    </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
This category contains some preference only for development purpose,
hence it is only visible under dev-build.