### PR TITLE
privately: drop savedInstanceState to reset Navigation

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
@@ -36,7 +36,8 @@ class PrivateModeActivity : LocaleAwareAppCompatActivity(),
     private lateinit var sharedViewModel: SharedViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+        // we don't keep any state if user leave Private-mode
+        super.onCreate(null)
 
         tabViewProvider = PrivateTabViewProvider(this)
 


### PR DESCRIPTION
The navigation tries to restore its state, but we don't keep WebView state in private mode for now. This commit ensure it won't restore any state. To ease issue #2452 