### PR TITLE
Fix intermittent issues when Espresso click event acts like long clic…

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/HomeTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/HomeTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.pressBack;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -74,8 +75,10 @@ public class HomeTest {
                     .check(matches(atPosition(0, hasDescendant(withText(defaultSites.get(0).getTitle())))));
 
             // Click and load the sample top site
+            // Some intermittent issues happens when performing a single click event, we add a rollback action in case of a long click action
+            // is triggered unexpectedly here. i.e. pressBack() can dismiss the popup menu.
             onView(ViewMatchers.withId(R.id.main_list))
-                    .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
+                    .perform(RecyclerViewActions.actionOnItemAtPosition(0, click(pressBack())));
 
             // After page loading completes
             IdlingRegistry.getInstance().register(loadingIdlingResource);

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SaveRestoreTabsTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SaveRestoreTabsTest.java
@@ -18,6 +18,7 @@ import org.mozilla.focus.utils.AndroidTestUtils;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.pressBack;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
@@ -54,8 +55,10 @@ public class SaveRestoreTabsTest {
         activityRule.launchActivity(new Intent());
         onView(allOf(withId(R.id.counter_text), isDescendantOfA(withId(R.id.home_screen_menu)))).check(matches(withText("0")));
 
+        // Some intermittent issues happens when performing a single click event, we add a rollback action in case of a long click action
+        // is triggered unexpectedly here. i.e. pressBack() can dismiss the popup menu.
         onView(ViewMatchers.withId(R.id.main_list))
-                .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
+                .perform(RecyclerViewActions.actionOnItemAtPosition(0, click(pressBack())));
         relaunchActivity();
 
         onView(allOf(withId(R.id.counter_text), isDescendantOfA(withId(R.id.browser_screen_menu)))).check(matches(withText("1")));


### PR DESCRIPTION
…k event. Closes #2548, #2549
[Relevant discussion](https://stackoverflow.com/questions/32330671/android-espresso-performs-longclick-instead-of-click).
