### PR TITLE
Fix keyboard cover url bar in cutout and Xiaomi 6x. closes #2100

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -421,6 +421,10 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         urlView = (TextView) view.findViewById(R.id.display_url);
 
         backgroundView = view.findViewById(R.id.background);
+        view.findViewById(R.id.appbar).setOnApplyWindowInsetsListener((v, insets) -> {
+            ((FrameLayout.LayoutParams) v.getLayoutParams()).topMargin = insets.getSystemWindowInsetTop();
+            return insets;
+        });
         backgroundTransition = (TransitionDrawable) backgroundView.getBackground();
 
         tabCounter = view.findViewById(R.id.btn_tab_tray);

--- a/app/src/main/java/org/mozilla/focus/widget/ResizableKeyboardLayout.java
+++ b/app/src/main/java/org/mozilla/focus/widget/ResizableKeyboardLayout.java
@@ -7,13 +7,11 @@ package org.mozilla.focus.widget;
 
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.graphics.Rect;
 import android.support.annotation.Nullable;
 import android.support.design.widget.CoordinatorLayout;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
 
 import org.mozilla.focus.R;
 
@@ -28,13 +26,11 @@ import org.mozilla.focus.R;
  * is showing. That can be useful for things like FABs that you don't need when someone is typing.
  */
 public class ResizableKeyboardLayout extends CoordinatorLayout {
-    private final Rect rect;
-    private View decorView;
 
     private final int idOfViewToHide;
-    private
+
     @Nullable
-    View viewToHide;
+    private View viewToHide;
     private int marginBottom;
 
     public ResizableKeyboardLayout(Context context) {
@@ -48,8 +44,6 @@ public class ResizableKeyboardLayout extends CoordinatorLayout {
     public ResizableKeyboardLayout(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
 
-        rect = new Rect();
-
         final TypedArray styleAttributeArray = getContext().getTheme().obtainStyledAttributes(
                 attrs,
                 R.styleable.ResizableKeyboardLayout,
@@ -60,21 +54,8 @@ public class ResizableKeyboardLayout extends CoordinatorLayout {
         } finally {
             styleAttributeArray.recycle();
         }
-    }
-
-    // Zerda modification: Intercept bottomMargin
-    @Override
-    public void setLayoutParams(ViewGroup.LayoutParams params) {
-        super.setLayoutParams(params);
-        if (params instanceof MarginLayoutParams) {
-            marginBottom = (((MarginLayoutParams) params).bottomMargin);
-        }
-    }
-
-    private ViewTreeObserver.OnGlobalLayoutListener layoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
-        @Override
-        public void onGlobalLayout() {
-            int difference = calculateDifferenceBetweenHeightAndUsableArea();
+        this.setOnApplyWindowInsetsListener((v, insets) -> {
+            int difference = insets.getSystemWindowInsetBottom();
 
             if (difference != 0) {
                 // Keyboard showing -> Set difference has bottom padding.
@@ -102,24 +83,22 @@ public class ResizableKeyboardLayout extends CoordinatorLayout {
                     }
                 }
             }
+            return insets;
+        });
+    }
+
+    // Zerda modification: Intercept bottomMargin
+    @Override
+    public void setLayoutParams(ViewGroup.LayoutParams params) {
+        super.setLayoutParams(params);
+        if (params instanceof MarginLayoutParams) {
+            marginBottom = (((MarginLayoutParams) params).bottomMargin);
         }
-    };
-
-    private int calculateDifferenceBetweenHeightAndUsableArea() {
-        if (decorView == null) {
-            decorView = getRootView();
-        }
-
-        decorView.getWindowVisibleDisplayFrame(rect);
-
-        return getResources().getDisplayMetrics().heightPixels - rect.bottom;
     }
 
     @Override
     public void onAttachedToWindow() {
         super.onAttachedToWindow();
-
-        getViewTreeObserver().addOnGlobalLayoutListener(layoutListener);
 
         if (idOfViewToHide != -1) {
             viewToHide = findViewById(idOfViewToHide);
@@ -129,8 +108,6 @@ public class ResizableKeyboardLayout extends CoordinatorLayout {
     @Override
     public void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-
-        getViewTreeObserver().removeOnGlobalLayoutListener(layoutListener);
 
         viewToHide = null;
     }

--- a/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragment.kt
@@ -15,13 +15,13 @@ import android.webkit.CookieManager
 import android.webkit.WebView
 import android.widget.ImageButton
 import android.widget.ImageView
+import android.widget.LinearLayout
 import android.widget.TextView
 import org.mozilla.focus.BuildConfig
 import org.mozilla.focus.R
 import org.mozilla.focus.locale.LocaleAwareFragment
 import org.mozilla.focus.menu.WebContextMenu
 import org.mozilla.focus.telemetry.TelemetryWrapper
-import org.mozilla.urlutils.UrlUtils
 import org.mozilla.focus.utils.ViewUtils
 import org.mozilla.focus.widget.AnimatedProgressBar
 import org.mozilla.focus.widget.BackKeyHandleable
@@ -38,6 +38,7 @@ import org.mozilla.rocket.tabs.utils.DefaultTabsViewListener
 import org.mozilla.rocket.tabs.utils.TabUtil
 import org.mozilla.rocket.tabs.web.Download
 import org.mozilla.rocket.tabs.web.DownloadCallback
+import org.mozilla.urlutils.UrlUtils
 
 private const val SITE_GLOBE = 0
 private const val SITE_LOCK = 1
@@ -114,6 +115,11 @@ class BrowserFragment : LocaleAwareFragment(),
                     it.isEnabled = false
                     it.setOnClickListener { onNextClicked() }
                 }
+
+        view.findViewById<View>(R.id.appbar).setOnApplyWindowInsetsListener { v, insets ->
+            (v.layoutParams as LinearLayout.LayoutParams).topMargin = insets.systemWindowInsetTop
+            insets
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
@@ -8,37 +7,24 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <FrameLayout
+    <LinearLayout
         android:id="@+id/browser_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@android:color/white">
+        android:background="@android:color/white"
+        android:orientation="vertical">
 
-        <View
+        <FrameLayout
             android:id="@+id/background"
             android:layout_width="match_parent"
-            android:layout_height="50dp"
-            android:background="@drawable/animated_background" />
-
-        <org.mozilla.focus.widget.ResizableKeyboardLayout
-            android:id="@+id/main_content"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginBottom="49dp"
-            android:layout_marginTop="25dp"
-            android:clipChildren="false"
-            android:orientation="vertical">
-
-            <FrameLayout
-                android:id="@+id/webview_slot"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginTop="26dp" />
+            android:layout_height="wrap_content"
+            android:background="@drawable/animated_background">
 
             <android.support.design.widget.AppBarLayout
                 android:id="@+id/appbar"
+                android:layout_gravity="bottom"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="26dp"
                 android:background="@android:color/transparent"
                 android:clipChildren="false"
                 app:elevation="0dp">
@@ -46,7 +32,7 @@
                 <FrameLayout
                     android:id="@+id/urlbar"
                     android:layout_width="match_parent"
-                    android:layout_height="26dp"
+                    android:layout_height="match_parent"
                     android:clipChildren="false"
                     app:layout_scrollFlags="">
 
@@ -76,12 +62,28 @@
 
             </android.support.design.widget.AppBarLayout>
 
+        </FrameLayout>
+
+        <org.mozilla.focus.widget.ResizableKeyboardLayout
+            android:id="@+id/main_content"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginBottom="49dp"
+            android:clipChildren="false"
+            android:orientation="vertical">
+
+            <FrameLayout
+                android:id="@+id/webview_slot"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+
             <include
                 layout="@layout/find_in_page"
                 android:visibility="gone" />
 
         </org.mozilla.focus.widget.ResizableKeyboardLayout>
-    </FrameLayout>
+    </LinearLayout>
 
     <View
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_private_browser.xml
+++ b/app/src/main/res/layout/fragment_private_browser.xml
@@ -6,18 +6,59 @@
     android:layout_height="match_parent"
     tools:context="org.mozilla.rocket.privately.browse.BrowserFragment">
 
-    <FrameLayout
+    <LinearLayout
         android:id="@+id/browser_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:orientation="vertical"
         tools:background="#FF0000">
+
+        <android.support.design.widget.AppBarLayout
+            android:id="@+id/appbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:clipChildren="false"
+            app:elevation="0dp">
+
+            <FrameLayout
+                android:id="@+id/urlbar"
+                android:layout_width="match_parent"
+                android:layout_height="26dp"
+                android:clipChildren="false"
+                app:layout_scrollFlags="">
+
+                <include layout="@layout/toolbar" />
+
+                <!-- divider between appbar and web-vew, will be covered by progress bar -->
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_gravity="bottom"
+                    android:background="@color/privateBackground"
+                    tools:background="#FF0000" />
+
+                <org.mozilla.focus.widget.AnimatedProgressBar
+                    android:id="@+id/progress"
+                    style="@style/Base.Widget.AppCompat.ProgressBar.Horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="3dp"
+                    android:layout_gravity="bottom"
+                    android:layout_marginBottom="-1dp"
+                    android:importantForAccessibility="yes"
+                    android:progressDrawable="@drawable/photon_progressbar"
+                    app:shiftDuration="@integer/progress_shift_duration"
+                    app:wrapShiftDrawable="true"
+                    tools:progress="50" />
+            </FrameLayout>
+
+        </android.support.design.widget.AppBarLayout>
 
         <org.mozilla.focus.widget.ResizableKeyboardLayout
             android:id="@+id/main_content"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginBottom="48dp"
-            android:layout_marginTop="25dp"
             android:clipChildren="false"
             android:orientation="vertical">
 
@@ -25,53 +66,11 @@
                 android:id="@+id/tab_view_slot"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_marginTop="26dp"
                 tools:background="#333333" />
-
-            <android.support.design.widget.AppBarLayout
-                android:id="@+id/appbar"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@android:color/transparent"
-                android:clipChildren="false"
-                app:elevation="0dp">
-
-                <FrameLayout
-                    android:id="@+id/urlbar"
-                    android:layout_width="match_parent"
-                    android:layout_height="26dp"
-                    android:clipChildren="false"
-                    app:layout_scrollFlags="">
-
-                    <include layout="@layout/toolbar" />
-
-                    <!-- divider between appbar and web-vew, will be covered by progress bar -->
-                    <View
-                        android:layout_width="match_parent"
-                        android:layout_height="1dp"
-                        android:layout_gravity="bottom"
-                        android:background="@color/privateBackground"
-                        tools:background="#FF0000" />
-
-                    <org.mozilla.focus.widget.AnimatedProgressBar
-                        android:id="@+id/progress"
-                        style="@style/Base.Widget.AppCompat.ProgressBar.Horizontal"
-                        android:layout_width="match_parent"
-                        android:layout_height="3dp"
-                        android:layout_gravity="bottom"
-                        android:layout_marginBottom="-1dp"
-                        android:importantForAccessibility="yes"
-                        android:progressDrawable="@drawable/photon_progressbar"
-                        app:shiftDuration="@integer/progress_shift_duration"
-                        app:wrapShiftDrawable="true"
-                        tools:progress="50" />
-                </FrameLayout>
-
-            </android.support.design.widget.AppBarLayout>
 
         </org.mozilla.focus.widget.ResizableKeyboardLayout>
 
-    </FrameLayout>
+    </LinearLayout>
 
     <include layout="@layout/fragment_private_browser_item_menu_button" />
 


### PR DESCRIPTION
Currently, the keyboard will be hidden when the progress bar updates.
This is caused by a bug in Find in Page feature. Other than that, this PR should fix the issue.