### PR TITLE
tabs: implement setFindListener

### DIFF
--- a/components/feature/tabs/src/test/java/org/mozilla/rocket/tabs/SessionManagerTest.java
+++ b/components/feature/tabs/src/test/java/org/mozilla/rocket/tabs/SessionManagerTest.java
@@ -411,6 +411,11 @@ public class SessionManagerTest {
         }
 
         @Override
+        public void setFindListener(FindListener callback) {
+
+        }
+
+        @Override
         public void onPause() {
 
         }


### PR DESCRIPTION
To implement Find-in-page, we added an interface setFindListener. But I missed the test case.