### PR TITLE
Send the last ping before the user disable "Send Usage Data"

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -26,7 +26,6 @@ import org.mozilla.focus.utils.AppConstants;
 import org.mozilla.focus.utils.DialogUtils;
 import org.mozilla.focus.utils.FirebaseHelper;
 import org.mozilla.focus.widget.DefaultBrowserPreference;
-import org.mozilla.rocket.privately.PrivateMode;
 
 import java.util.Locale;
 
@@ -146,7 +145,8 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
                     .replace(R.id.container, new SettingsFragment())
                     .commit();
             return;
-        } else {
+            // TelemetrySwitchPreference will handle this
+        } else  if (!key.equals(getString(R.string.pref_key_telemetry))) {
             // For other events, we handle them here.
             TelemetryWrapper.settingsEvent(key, String.valueOf(sharedPreferences.getAll().get(key)));
         }

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
@@ -45,7 +45,6 @@ import org.mozilla.telemetry.storage.FileTelemetryStorage;
 import org.mozilla.telemetry.storage.TelemetryStorage;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -237,6 +236,7 @@ public final class TelemetryWrapper {
                             resources.getString(R.string.pref_key_webview_version),
                             resources.getString(R.string.pref_key_locale))
                     .setSettingsProvider(new CustomSettingsProvider())
+                    .setMinimumEventsForUpload(1)   // if the user open MainActivity and goes to Setting Fragment and disable "Send Usage Data", we still want to send that event.
                     .setCollectionEnabled(telemetryEnabled)
                     .setUploadEnabled(telemetryEnabled);
 


### PR DESCRIPTION
closes #2487

Confirmed with UX and product.
We'll send this ping using our best effort.
If the battery is low and the network is slow, the ping won't be sent.
This is because the Telemetry library uses JobScheduler to upload the ping.
And there's no control at our end. In the above situation, data loss is acceptable.
