### PR TITLE
Use PrivateModeActivty to determine if the application is in private mode

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -233,7 +233,6 @@ object TelemetryWrapper {
             val telemetryEnabled = isTelemetryEnabled(context)
 
             updateDefaultBrowserStatus(context)
-            updatePrefValue(context, resources.getString(R.string.pref_key_webview_version), DebugUtils.loadWebViewVersion(context))
 
             val configuration = TelemetryConfiguration(context)
                     .setServerEndpoint("https://incoming.telemetry.mozilla.org")
@@ -245,7 +244,6 @@ object TelemetryWrapper {
                             resources.getString(R.string.pref_key_performance_block_images),
                             resources.getString(R.string.pref_key_default_browser),
                             resources.getString(R.string.pref_key_storage_save_downloads_to),
-                            resources.getString(R.string.pref_key_webview_version),
                             resources.getString(R.string.pref_key_locale))
                     .setSettingsProvider(CustomSettingsProvider())
                     .setCollectionEnabled(telemetryEnabled)
@@ -1038,7 +1036,6 @@ object TelemetryWrapper {
                 prefKeyWhitelist[context.getString(R.string.pref_key_help)] = "help"
                 prefKeyWhitelist[context.getString(R.string.pref_key_rights)] = "rights"
 
-                prefKeyWhitelist[context.getString(R.string.pref_key_webview_version)] = "webview_version"
                 // data saving
                 prefKeyWhitelist[context.getString(R.string.pref_key_data_saving_block_ads)] = "saving_block_ads"
                 prefKeyWhitelist[context.getString(R.string.pref_key_data_saving_block_webfonts)] = "data_webfont"

--- a/app/src/main/java/org/mozilla/rocket/component/RocketLauncherActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/component/RocketLauncherActivity.kt
@@ -4,12 +4,16 @@ import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import org.mozilla.focus.activity.MainActivity
+import org.mozilla.focus.telemetry.TelemetryWrapper
 
 
 class RocketLauncherActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        TelemetryWrapper.init(this)
+
         val action = LaunchIntentDispatcher.dispatch(this, intent)
         when (action) {
             LaunchIntentDispatcher.Action.HANDLED -> finish()

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -27,8 +27,6 @@
 
     <string name="pref_key_locale" translatable="false"><xliff:g id="preference_key">pref_locale</xliff:g></string>
 
-    <string name="pref_key_webview_version" translatable="false"><xliff:g id="preference_key">pref_webview_version</xliff:g></string>
-
     <string name="pref_key_focus_tab_id" translatable="false"><xliff:g id="preference_key">pref_key_focus_tab_id</xliff:g></string>
 
     <string name="pref_key_category_development" translatable="false"><xliff:g id="preference_key">pref_key_category_development</xliff:g></string>


### PR DESCRIPTION
closes #2542

FocusApplication need to know if we are in private mode process, so it
can know when to override getCacheDir to provide the cache folder for
webview/chromium

We use process's name to see if it contains "private_mode" using
acitivityManager.getRunningAppProcesses(). But this method
sometimes return null list so a NullPointerException will be thrown
if we want to use it to check if we are in private mode.

We want to use a new way to determine if we are in prviate mode
process. We want to use the existance of PrivateModeActivity here.

But Telemetry.init() call in FocsApplication will make this hard cause
it make getCacheDir called much more early than PrivateModeActivity is
created.  This is because it checked the webview's version in
TelemtryWrapper.init() and call the constructor of WebView.

This makes the chromium code call context.getApplicationContext().getCacheDir() too
early even before the acitvity is created.

Our solution here is to remove the webview version check. But maybe we
can put the version check after the first webView is created and save it
to a shared preference. At the next launch, we just read the pref but we
don't create a webview again just to check the version.

The assumption here is that as long as there's PrivateModateActivity,
this application is in Private Mode process.
This assumption won't hold true if private mode lives in the same
process of normal mode. But this is the desgin right now.

We should also test if the activity is killed by the system, will this
still work? I assume it will cause there'll never be a
PrivateModeActivity in normal mode.
Need more testing so this can be landed.