### PR TITLE
Promote "set as default browser" on the first launch on preloads #2137

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
@@ -134,7 +134,7 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
 
     private fun promoteSetDefaultBrowserIfPreload(): FirstrunFragment {
         // if it's a system app(preload), we'll like to promote set default browser when the user finish first run
-        if (isSystemApp() && !AppConstants.isReleaseBuild()) {
+        if (isSystemApp() || !AppConstants.isReleaseBuild()) {
             DialogUtils.showDefaultSettingNotification(context)
         }
         return this


### PR DESCRIPTION
We also allow Nightly and debug build to show the notification after first run finish