### PR TITLE
When excludeFromRecents is true, onTaskRemoved will be called thus clear the private mode.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -93,7 +93,6 @@
             android:enabled="true"
             android:exported="false"
             android:launchMode="singleTask"
-            android:excludeFromRecents="true"
             android:process=":private_mode"
             android:screenOrientation="portrait"
             android:configChanges="orientation|screenSize"


### PR DESCRIPTION
for #2555. Now private mode activity will stays in Recent Apps. UX confirmed it's okay.
This is a partial fix cause sometimes when launching new activities(not in recent apps) will still cause this problem.

So I'll need to complete the survey:
1. why it works in Android 5 & 6
2. why launching other activity will cause this.

