### PR TITLE
tabs: remove redundant implementations from SessionManager

### DIFF
--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
@@ -350,12 +350,6 @@ class SessionManager @JvmOverloads constructor(
 
     internal inner class SessionObserver(var source: Session) : Session.Observer {
 
-        override fun handleExternalUrl(url: String?): Boolean {
-            // only return false if none of listeners handled external url.
-            val consumers = wrapConsumers<String?> { handleExternalUrl(it) }
-            return Consumable.from(url).consumeBy(consumers)
-        }
-
         override fun onCreateWindow(
                 isDialog: Boolean,
                 isUserGesture: Boolean,


### PR DESCRIPTION
BrowserFragment is already handled it, and it should be handled by UI
except SessionManager.

to close #2779