### PR TITLE
Move Find in Page Telemetry cancel call after the visibility check.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -1001,7 +1001,6 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
 
     private void hideFindInPage() {
         findInPage.hide();
-        TelemetryWrapper.findInPage(TelemetryWrapper.FIND_IN_PAGE.DISMISS);
     }
 
     class SessionObserver implements Session.Observer {

--- a/app/src/main/java/org/mozilla/focus/widget/FindInPage.kt
+++ b/app/src/main/java/org/mozilla/focus/widget/FindInPage.kt
@@ -98,6 +98,8 @@ class FindInPage : TabView.FindListener, BackKeyHandleable {
         queryText.text = null
         queryText.clearFocus()
         container.visibility = View.GONE
+        TelemetryWrapper.findInPage(TelemetryWrapper.FIND_IN_PAGE.DISMISS)
+
     }
 
     private fun initViews() {


### PR DESCRIPTION
Closes #2736

This prevents the redundant call to the telemetry.