### PR TITLE
Upgrade LeakCanary version to fix FOREGROUND_SERVICE force close

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -19,7 +19,7 @@ object Versions {
     const val navigation = "1.0.0-alpha03"
     const val findbugs = "3.0.1"
     const val lottie = "2.7.0"
-    const val leakcanary = "1.5.4"
+    const val leakcanary = "1.6.2"
     const val android_components = "0.27.0"
     const val adjust = "4.11.4"
     const val junit = "4.12"


### PR DESCRIPTION
https://github.com/square/leakcanary/blob/master/CHANGELOG.md#version-162-2018-10-16

github.com/square/leakcanary `#1076` `#912`
