### PR TITLE
Ac/involve engine session

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -210,6 +210,11 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}"
 
+    // We didn't use CustomTabs so far. This is a build hack to force Android-Components to use
+    // same version of support library as we are. Android-Components depends on CustomTabs which
+    // version will be override by this.
+    // We can get rid of this once Android-Components' issue #404 has been resolve.
+    implementation "com.android.support:customtabs:${Versions.support}"
     implementation "com.android.support:support-v4:${Versions.support}"
     implementation "com.android.support:appcompat-v7:${Versions.support}"
     implementation "com.android.support:design:${Versions.support}"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -230,6 +230,7 @@ dependencies {
         transitive = false
     })
 
+    implementation "org.mozilla.components:browser-session:${Versions.android_components}"
     implementation "org.mozilla.components:service-telemetry:${Versions.android_components}"
     implementation "org.mozilla.components:browser-domains:${Versions.android_components}"
     implementation "org.mozilla.components:ui-autocomplete:${Versions.android_components}"

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -75,10 +75,10 @@ import org.mozilla.focus.utils.SupportUtils;
 import org.mozilla.focus.viewmodel.BookmarkViewModel;
 import org.mozilla.focus.web.GeoPermissionCache;
 import org.mozilla.focus.web.WebViewProvider;
-import org.mozilla.rocket.nightmode.AdjustBrightnessDialog;
 import org.mozilla.focus.widget.FragmentListener;
 import org.mozilla.focus.widget.TabRestoreMonitor;
 import org.mozilla.rocket.component.LaunchIntentDispatcher;
+import org.mozilla.rocket.nightmode.AdjustBrightnessDialog;
 import org.mozilla.rocket.privately.PrivateMode;
 import org.mozilla.rocket.privately.PrivateModeActivity;
 import org.mozilla.rocket.promotion.PromotionModel;
@@ -87,6 +87,7 @@ import org.mozilla.rocket.promotion.PromotionViewContract;
 import org.mozilla.rocket.tabs.Session;
 import org.mozilla.rocket.tabs.SessionManager;
 import org.mozilla.rocket.tabs.TabView;
+import org.mozilla.rocket.tabs.TabViewEngineSession;
 import org.mozilla.rocket.tabs.TabViewProvider;
 import org.mozilla.rocket.tabs.TabsSessionProvider;
 import org.mozilla.rocket.theme.ThemeManager;
@@ -1032,9 +1033,9 @@ public class MainActivity extends BaseActivity implements FragmentListener,
     }
 
     @Override
-    public void onQueryComplete(List<Session> session, String currentTabId) {
+    public void onQueryComplete(List<SessionManager.SessionWithState> states, String currentTabId) {
         isTabRestoredComplete = true;
-        getSessionManager().restoreTabs(session, currentTabId);
+        getSessionManager().restore(states, currentTabId);
         Session currentTab = getSessionManager().getFocusSession();
         if (!Settings.getInstance(this).shouldShowFirstrun() && currentTab != null && !getSupportFragmentManager().isStateSaved()) {
             screenNavigator.restoreBrowserScreen(currentTab.getId());

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -1053,7 +1053,9 @@ public class MainActivity extends BaseActivity implements FragmentListener,
 
         List<Session> sessions = getSessionManager().getTabs();
         for (Session s : sessions) {
-            s.syncFromView();
+            if (s.getEngineSession() != null) {
+                s.getEngineSession().saveState();
+            }
         }
 
         final String currentTabId = (getSessionManager().getFocusSession() != null)

--- a/app/src/main/java/org/mozilla/focus/download/EnqueueDownloadTask.java
+++ b/app/src/main/java/org/mozilla/focus/download/EnqueueDownloadTask.java
@@ -49,8 +49,9 @@ public class EnqueueDownloadTask extends AsyncTask<Void, Void, EnqueueDownloadTa
         }
 
         final String cookie = CookieManager.getInstance().getCookie(download.getUrl());
-        final String fileName = URLUtil.guessFileName(
-                download.getUrl(), download.getContentDisposition(), download.getMimeType());
+        final String fileName = (download.getName() != null)
+                ? download.getName()
+                : URLUtil.guessFileName(download.getUrl(), download.getContentDisposition(), download.getMimeType());
 
         // so far each download always return null even for an image.
         // But we might move downloaded file to another directory.

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -864,9 +864,7 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
 
     public boolean canGoForward() {
         return sessionManager.getFocusSession() != null
-                && sessionManager.getFocusSession().getEngineSession() != null
-                && sessionManager.getFocusSession().getEngineSession().getTabView() != null
-                && sessionManager.getFocusSession().getEngineSession().getTabView().canGoForward();
+                && sessionManager.getFocusSession().getCanGoForward();
     }
 
     public boolean isLoading() {
@@ -875,9 +873,7 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
 
     public boolean canGoBack() {
         return sessionManager.getFocusSession() != null
-                && sessionManager.getFocusSession().getEngineSession() != null
-                && sessionManager.getFocusSession().getEngineSession().getTabView() != null
-                && sessionManager.getFocusSession().getEngineSession().getTabView().canGoBack();
+                && sessionManager.getFocusSession().getCanGoBack();
     }
 
     public void goBack() {
@@ -1268,6 +1264,10 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
                     false);
             permissionHandler.tryAction(BrowserFragment.this, Manifest.permission.WRITE_EXTERNAL_STORAGE, ACTION_DOWNLOAD, d);
             return true;
+        }
+
+        @Override
+        public void onNavigationStateChanged(@NotNull Session session, boolean canGoBack, boolean canGoForward) {
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -50,6 +50,7 @@ import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 import android.widget.Toast;
 
+import org.jetbrains.annotations.NotNull;
 import org.mozilla.focus.R;
 import org.mozilla.focus.download.EnqueueDownloadTask;
 import org.mozilla.focus.locale.LocaleAwareFragment;
@@ -428,7 +429,6 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
 
         sessionManager.register(this.managerObserver, this, false);
         sessionManager.setDownloadCallback(downloadCallback);
-        sessionManager.setFindListener(findInPage);
 
         if (tabCounter != null && isTabRestoredComplete()) {
             tabCounter.setCount(sessionManager.getTabsCount());
@@ -1246,6 +1246,11 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
 
         private boolean isForegroundSession(Session tab) {
             return sessionManager.getFocusSession() == tab;
+        }
+
+        @Override
+        public void onFindResult(@NotNull Session session, @NotNull mozilla.components.browser.session.Session.FindResult result) {
+            findInPage.onFindResultReceived(result);
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -1006,7 +1006,7 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         findInPage.hide();
     }
 
-    class SessionObserver implements Session.Observer {
+    class SessionObserver implements Session.Observer, TabViewEngineSession.Client {
         @Nullable
         private Session session;
         private HistoryInserter historyInserter = new HistoryInserter();
@@ -1077,16 +1077,6 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         }
 
         @Override
-        public boolean onCreateWindow(boolean isDialog, boolean isUserGesture, @Nullable Message msg) {
-            // session manager handled this
-            return false;
-        }
-
-        @Override
-        public void onCloseWindow(@Nullable TabView tabView) {
-        }
-
-        @Override
         public void onProgress(@NonNull Session session, int progress) {
             if (!isForegroundSession(session)) {
                 return;
@@ -1111,7 +1101,7 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         }
 
         @Override
-        public boolean onShowFileChooser(@NonNull TabView tabView,
+        public boolean onShowFileChooser(@NonNull TabViewEngineSession es,
                                          @NonNull ValueCallback<Uri[]> filePathCallback,
                                          @NonNull WebChromeClient.FileChooserParams fileChooserParams) {
             if (!isForegroundSession(session)) {

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -23,7 +23,6 @@ import android.graphics.drawable.TransitionDrawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
-import android.os.Message;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -428,7 +427,6 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         sessionManager = TabsSessionProvider.getOrThrow(getActivity());
 
         sessionManager.register(this.managerObserver, this, false);
-        sessionManager.setDownloadCallback(downloadCallback);
 
         if (tabCounter != null && isTabRestoredComplete()) {
             tabCounter.setCount(sessionManager.getTabsCount());
@@ -1251,6 +1249,25 @@ public class BrowserFragment extends LocaleAwareFragment implements View.OnClick
         @Override
         public void onFindResult(@NotNull Session session, @NotNull mozilla.components.browser.session.Session.FindResult result) {
             findInPage.onFindResultReceived(result);
+        }
+
+        @Override
+        public boolean onDownload(@NotNull Session session, @NotNull mozilla.components.browser.session.Download download) {
+            FragmentActivity activity = getActivity();
+            if (activity == null
+                    || !activity.getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) {
+                return false;
+            }
+
+            Download d = new Download(download.getUrl(),
+                    download.getFileName(),
+                    download.getUserAgent(),
+                    "",
+                    download.getContentType(),
+                    download.getContentLength(),
+                    false);
+            permissionHandler.tryAction(BrowserFragment.this, Manifest.permission.WRITE_EXTERNAL_STORAGE, ACTION_DOWNLOAD, d);
+            return true;
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/menu/WebContextMenu.java
+++ b/app/src/main/java/org/mozilla/focus/menu/WebContextMenu.java
@@ -210,7 +210,7 @@ public class WebContextMenu {
 
         // Try to find parent tab for new tab
         for (final Session tab : tabs) {
-            if (tab.getTabView() == source) {
+            if (tab.getEngineSession().getTabView() == source) {
                 parentId = tab.getId();
                 break;
             }

--- a/app/src/main/java/org/mozilla/focus/menu/WebContextMenu.java
+++ b/app/src/main/java/org/mozilla/focus/menu/WebContextMenu.java
@@ -156,14 +156,14 @@ public class WebContextMenu {
                             getImgHeaderTask.setCallback(new GetImgHeaderTask.Callback() {
                                 @Override
                                 public void setMIMEType(String mimeType) {
-                                    final Download download = new Download(hitTarget.imageURL, null, null, mimeType, -1, true);
+                                    final Download download = new Download(hitTarget.imageURL, null, null, null, mimeType, -1, true);
                                     callback.onDownloadStart(download);
                                 }
                             });
 
                             getImgHeaderTask.execute(hitTarget.imageURL);
                         } else {
-                            final Download download = new Download(hitTarget.imageURL, null, null, null, -1, true);
+                            final Download download = new Download(hitTarget.imageURL, null, null, null, null, -1, true);
                             callback.onDownloadStart(download);
                         }
 

--- a/app/src/main/java/org/mozilla/focus/persistence/TabModelStore.java
+++ b/app/src/main/java/org/mozilla/focus/persistence/TabModelStore.java
@@ -82,9 +82,9 @@ public class TabModelStore {
 
         @Override
         protected List<SessionManager.SessionWithState> doInBackground(Void... voids) {
-            if (tabsDatabase != null) {
+            final Context context = contextRef.get();
+            if (context != null && tabsDatabase != null) {
                 List<TabEntity> tabEntityList = tabsDatabase.tabDao().getTabs();
-                Context context = contextRef.get();
 
                 List<Session> sessions = new ArrayList<>();
                 for (final TabEntity entity : tabEntityList) {

--- a/app/src/main/java/org/mozilla/focus/persistence/TabModelStore.java
+++ b/app/src/main/java/org/mozilla/focus/persistence/TabModelStore.java
@@ -88,8 +88,8 @@ public class TabModelStore {
                 for (final TabEntity entity : tabEntityList) {
                     Session session = new Session(entity.getId(),
                             entity.getParentId(),
-                            entity.getTitle());
-                    session.setUrl(entity.getUrl());
+                            entity.getUrl());
+                    session.setTitle(entity.getTitle());
 
                     sessions.add(session);
                 }

--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabsSessionModel.kt
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabsSessionModel.kt
@@ -102,10 +102,6 @@ internal class TabsSessionModel(private val sessionManager: SessionManager) : Ta
             session.let { onTabModelChanged(it) }
         }
 
-        override fun updateFailingUrl(url: String?, updateFromError: Boolean) {
-            session?.let { onTabModelChanged(it) }
-        }
-
         override fun onTitleChanged(session: Session, title: String?) {
             session.let { onTabModelChanged(it) }
         }

--- a/app/src/main/java/org/mozilla/focus/widget/FindInPage.kt
+++ b/app/src/main/java/org/mozilla/focus/widget/FindInPage.kt
@@ -104,14 +104,9 @@ class FindInPage : TabView.FindListener, BackKeyHandleable {
 
     private fun initViews() {
         fun obtainWebView(): WebView? {
-            if (session != null && session is Session) {
-                val tabView = (session as Session).tabView
-                if (tabView != null && tabView is WebView) {
-                    return tabView
-                }
-            }
-            return null
+            return (session?.engineSession?.tabView as WebView)
         }
+
         closeBtn.setOnClickListener {
             hide()
             TelemetryWrapper.findInPage(TelemetryWrapper.FIND_IN_PAGE.DISMISS_BY_CLOSE)

--- a/app/src/main/java/org/mozilla/focus/widget/FindInPage.kt
+++ b/app/src/main/java/org/mozilla/focus/widget/FindInPage.kt
@@ -13,13 +13,13 @@ import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.webkit.WebView
 import android.widget.TextView
+import mozilla.components.browser.session.Session.FindResult
 import org.mozilla.focus.R
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.ViewUtils
 import org.mozilla.rocket.tabs.Session
-import org.mozilla.rocket.tabs.TabView
 
-class FindInPage : TabView.FindListener, BackKeyHandleable {
+class FindInPage : BackKeyHandleable {
     private val container: View
     private val queryText: TextView
     private val resultText: TextView
@@ -56,9 +56,9 @@ class FindInPage : TabView.FindListener, BackKeyHandleable {
         }
     }
 
-    override fun onFindResultReceived(activeMatchOrdinal: Int,
-                                      numOfMatches: Int,
-                                      isDoneCounting: Boolean) {
+    fun onFindResultReceived(result: FindResult) {
+        val activeMatchOrdinal = result.activeMatchOrdinal
+        val numOfMatches = result.numberOfMatches
         if (numOfMatches > 0) {
             // We don't want the presentation of the activeMatchOrdinal to be zero indexed. So let's
             // increment it by one.

--- a/app/src/test/java/org/mozilla/focus/web/DownloadTest.java
+++ b/app/src/test/java/org/mozilla/focus/web/DownloadTest.java
@@ -20,6 +20,7 @@ public class DownloadTest {
     public void testGetters() {
         final Download download = new Download(
                 "https://www.mozilla.org/image.png",
+                null,
                 "Focus/1.0",
                 "Content-Disposition: attachment; filename=\"filename.png\"",
                 "image/png",
@@ -40,6 +41,7 @@ public class DownloadTest {
         {
             final Download download = new Download(
                     "https://www.mozilla.org/image.png",
+                    null,
                     "Focus/1.0",
                     "Content-Disposition: attachment; filename=\"filename.png\"",
                     "image/png",

--- a/app/src/webkit/java/org/mozilla/focus/webkit/WebkitView.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/WebkitView.java
@@ -15,6 +15,7 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.webkit.CookieManager;
 import android.webkit.DownloadListener;
+import android.webkit.URLUtil;
 import android.webkit.WebBackForwardList;
 import android.webkit.WebHistoryItem;
 import android.webkit.WebSettings;
@@ -28,8 +29,6 @@ import org.mozilla.focus.history.BrowsingHistoryManager;
 import org.mozilla.focus.history.model.Site;
 import org.mozilla.focus.utils.AppConstants;
 import org.mozilla.focus.utils.SupportUtils;
-import org.mozilla.threadutils.ThreadUtils;
-import org.mozilla.urlutils.UrlUtils;
 import org.mozilla.focus.web.WebViewProvider;
 import org.mozilla.rocket.tabs.SiteIdentity;
 import org.mozilla.rocket.tabs.TabChromeClient;
@@ -37,6 +36,8 @@ import org.mozilla.rocket.tabs.TabView;
 import org.mozilla.rocket.tabs.TabViewClient;
 import org.mozilla.rocket.tabs.web.Download;
 import org.mozilla.rocket.tabs.web.DownloadCallback;
+import org.mozilla.threadutils.ThreadUtils;
+import org.mozilla.urlutils.UrlUtils;
 
 public class WebkitView extends NestedWebView implements TabView {
     private static final String KEY_CURRENTURL = "currenturl";
@@ -380,7 +381,8 @@ public class WebkitView extends NestedWebView implements TabView {
                 }
 
                 if (downloadCallback != null) {
-                    final Download download = new Download(url, userAgent, contentDisposition, mimetype, contentLength, false);
+                    final String name = URLUtil.guessFileName(url, contentDisposition, mimetype);
+                    final Download download = new Download(url, name, userAgent, contentDisposition, mimetype, contentLength, false);
                     downloadCallback.onDownloadStart(download);
                 }
             }

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/Session.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/Session.kt
@@ -6,13 +6,9 @@
 package org.mozilla.rocket.tabs
 
 import android.graphics.Bitmap
-import android.net.Uri
-import android.os.Message
 import android.text.TextUtils
 import android.view.View
 import android.webkit.GeolocationPermissions
-import android.webkit.ValueCallback
-import android.webkit.WebChromeClient
 import mozilla.components.browser.session.Session.SecurityInfo
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
@@ -101,26 +97,8 @@ class Session @JvmOverloads constructor(
 
         fun onUrlChanged(session: Session, url: String?) = Unit
 
-        /**
-         * Return true if the URL was handled, false if we should continue loading the current URL.
-         */
-        fun handleExternalUrl(url: String?): Boolean = false
-
-        fun updateFailingUrl(url: String?, updateFromError: Boolean) = Unit
-
-        fun onCreateWindow(isDialog: Boolean, isUserGesture: Boolean, msg: Message?) = false
-
-        fun onCloseWindow(tabView: TabView?) = Unit
-
         fun onProgress(session: Session, progress: Int) = Unit
 
-
-        /**
-         * @see android.webkit.WebChromeClient
-         */
-        fun onShowFileChooser(tabView: TabView,
-                              filePathCallback: ValueCallback<Array<Uri>>,
-                              fileChooserParams: WebChromeClient.FileChooserParams) = false
 
         fun onTitleChanged(session: Session, title: String?) = Unit
 

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/Session.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/Session.kt
@@ -9,6 +9,7 @@ import android.graphics.Bitmap
 import android.text.TextUtils
 import android.view.View
 import android.webkit.GeolocationPermissions
+import mozilla.components.browser.session.Session.FindResult
 import mozilla.components.browser.session.Session.SecurityInfo
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
@@ -71,6 +72,16 @@ class Session @JvmOverloads constructor(
         notifyObservers(old, new) { onSecurityChanged(this@Session, new.secure) }
     }
 
+    /**
+     * List of results of that latest "find in page" operation.
+     */
+    var findResults: List<FindResult> by Delegates.observable(emptyList()) { _, old, new ->
+        notifyObservers(old, new) {
+            if (new.isNotEmpty()) {
+                onFindResult(this@Session, findResults.last())
+            }
+        }
+    }
 
     fun isValid(): Boolean {
         return id.isNotBlank() && (url?.isNotBlank() ?: false)
@@ -90,21 +101,14 @@ class Session @JvmOverloads constructor(
     }
 
     interface Observer {
-
         fun onLoadingStateChanged(session: Session, loading: Boolean) = Unit
-
         fun onSecurityChanged(session: Session, isSecure: Boolean) = Unit
-
         fun onUrlChanged(session: Session, url: String?) = Unit
-
         fun onProgress(session: Session, progress: Int) = Unit
-
-
         fun onTitleChanged(session: Session, title: String?) = Unit
-
         fun onReceivedIcon(icon: Bitmap?) = Unit
-
         fun onLongPress(session: Session, hitTarget: TabView.HitTarget) = Unit
+        fun onFindResult(session: Session, result: FindResult) = Unit
 
         /**
          * Notify the host application that the current page has entered full screen mode.

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/Session.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/Session.kt
@@ -7,11 +7,9 @@ package org.mozilla.rocket.tabs
 
 import android.graphics.Bitmap
 import android.net.Uri
-import android.os.Bundle
 import android.os.Message
 import android.text.TextUtils
 import android.view.View
-import android.view.ViewGroup
 import android.webkit.GeolocationPermissions
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
@@ -19,8 +17,6 @@ import mozilla.components.browser.session.Session.SecurityInfo
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
 import org.mozilla.rocket.tabs.Session.Observer
-import org.mozilla.rocket.tabs.TabView.FindListener
-import org.mozilla.rocket.tabs.web.DownloadCallback
 import java.util.UUID
 import kotlin.properties.Delegates
 
@@ -33,24 +29,10 @@ class Session @JvmOverloads constructor(
         private val delegate: Observable<Observer> = ObserverRegistry()
 ) : Observable<Observer> by delegate {
 
-    var tabView: TabView? = null
-        private set
-
-    private var downloadCallback: DownloadCallback? = null
-    private var findListener: TabView.FindListener? = null
-
     var engineSession: TabViewEngineSession? = null
     var engineObserver: TabViewEngineSession.Observer? = null
 
-    var webViewState: Bundle? = null
-
     var favicon: Bitmap? = null
-
-    val securityState: Int
-        @SiteIdentity.SecurityState
-        get() = if (tabView == null) {
-            SiteIdentity.UNKNOWN
-        } else tabView!!.securityState
 
     val isFromExternal: Boolean
         get() = ID_EXTERNAL == parentId
@@ -93,114 +75,13 @@ class Session @JvmOverloads constructor(
         notifyObservers(old, new) { onSecurityChanged(this@Session, new.secure) }
     }
 
-    /**
-     * To sync session's properties to view, before saving. This method would be retired once we
-     * involve Observable class for those properties.
-     */
-    fun syncFromView() {
-        if (webViewState == null) {
-            webViewState = Bundle()
-        }
-        if (tabView != null) {
-            this.title = tabView!!.title
-            if (TextUtils.equals(tabView!!.url, this.url)) {
-                this.url = tabView!!.url
-            }
-            tabView!!.saveViewState(this.webViewState)
-        }
-    }
 
     fun isValid(): Boolean {
         return id.isNotBlank() && (url?.isNotBlank() ?: false)
     }
 
-    internal fun setDownloadCallback(callback: DownloadCallback?) {
-        downloadCallback = callback
-    }
-
-    internal fun setFindListener(listener: FindListener?) {
-        findListener = listener
-        if (tabView != null) {
-            tabView!!.setFindListener(listener)
-        }
-    }
-
-    fun setContentBlockingEnabled(enabled: Boolean) {
-        if (tabView != null) {
-            tabView!!.setContentBlockingEnabled(enabled)
-        }
-    }
-
-    fun setImageBlockingEnabled(enabled: Boolean) {
-        if (tabView != null) {
-            tabView!!.setImageBlockingEnabled(enabled)
-        }
-    }
-
     fun hasParentTab(): Boolean {
         return !isFromExternal && !TextUtils.isEmpty(parentId)
-    }
-
-    /**
-     * To detach @see{android.view.View} of this tab, if any, is detached from its parent.
-     */
-    fun detach() {
-        val hasParentView = (tabView != null
-                && tabView!!.view != null
-                && tabView!!.view.parent != null)
-        if (hasParentView) {
-            val parent = tabView!!.view.parent as ViewGroup
-            parent.removeView(tabView!!.view)
-        }
-    }
-
-    /* package */ internal fun destroy() {
-        setDownloadCallback(null)
-        setFindListener(null)
-        engineSession?.unregisterObservers()
-        unregisterObservers()
-
-        if (tabView != null) {
-            // ensure the view not bind to parent
-            detach()
-
-            tabView!!.destroy()
-        }
-    }
-
-    /* package */ internal fun resume() {
-        if (tabView != null) {
-            tabView!!.onResume()
-        }
-    }
-
-    /* package */ internal fun pause() {
-        if (tabView != null) {
-            tabView!!.onPause()
-        }
-    }
-
-    /* package */ internal fun initializeView(provider: TabViewProvider): TabView? {
-        val url = if (TextUtils.isEmpty(this.url)) this.initialUrl else this.url
-        if (tabView == null) {
-            tabView = provider.create()
-
-            engineSession = TabViewEngineSession()
-            engineSession?.tabView = tabView
-            engineObserver = TabViewEngineObserver(this, tabView!!)
-            engineSession?.register(engineObserver!!)
-
-            tabView!!.setDownloadCallback(downloadCallback)
-            tabView!!.setFindListener(findListener)
-
-            if (webViewState != null) {
-                tabView!!.restoreViewState(webViewState)
-            } else if (!TextUtils.isEmpty(url)) {
-                tabView!!.loadUrl(url)
-            }
-        }
-
-        return tabView
     }
 
     /**

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/Session.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/Session.kt
@@ -67,6 +67,21 @@ class Session @JvmOverloads constructor(
     }
 
     /**
+     * Navigation state, true if there's an history item to go back to, otherwise false.
+     */
+    var canGoBack: Boolean by Delegates.observable(false) { _, old, new ->
+        notifyObservers(old, new) { onNavigationStateChanged(this@Session, new, canGoForward) }
+    }
+
+    /**
+     * Navigation state, true if there's an history item to go forward to, otherwise false.
+     */
+    var canGoForward: Boolean by Delegates.observable(false) { _, old, new ->
+        notifyObservers(old, new) { onNavigationStateChanged(this@Session, canGoBack, new) }
+    }
+
+
+    /**
      * Security information indicating whether or not the current session is
      * for a secure URL, as well as the host and SSL certificate authority, if applicable.
      */
@@ -112,6 +127,7 @@ class Session @JvmOverloads constructor(
 
     interface Observer {
         fun onLoadingStateChanged(session: Session, loading: Boolean) = Unit
+        fun onNavigationStateChanged(session: Session, canGoBack: Boolean, canGoForward: Boolean) = Unit
         fun onSecurityChanged(session: Session, isSecure: Boolean) = Unit
         fun onUrlChanged(session: Session, url: String?) = Unit
         fun onProgress(session: Session, progress: Int) = Unit

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
@@ -18,7 +18,6 @@ import org.mozilla.rocket.tabs.SessionManager.Factor.FACTOR_TAB_ADDED
 import org.mozilla.rocket.tabs.SessionManager.Factor.FACTOR_TAB_REMOVED
 import org.mozilla.rocket.tabs.SessionManager.Factor.FACTOR_TAB_SWITCHED
 import org.mozilla.rocket.tabs.SessionManager.Observer
-import org.mozilla.rocket.tabs.TabView.FindListener
 import org.mozilla.rocket.tabs.utils.TabUtil
 import org.mozilla.rocket.tabs.web.DownloadCallback
 import java.lang.ref.WeakReference
@@ -45,7 +44,6 @@ class SessionManager @JvmOverloads constructor(
     private var focusRef = WeakReference<Session>(null)
 
     private var downloadCallback: DownloadCallback? = null
-    private var findListener: FindListener? = null
 
     /**
      * To get count of sessions in this session.
@@ -255,15 +253,6 @@ class SessionManager @JvmOverloads constructor(
         }
     }
 
-    fun setFindListener(findListener: FindListener?) {
-        this.findListener = findListener
-        if (hasTabs()) {
-            for (session in sessions) {
-                session.engineSession?.tabView?.setFindListener(findListener)
-            }
-        }
-    }
-
     /**
      * To destroy this session, and it also destroy any sessions in this session.
      * This method should be called after any View has been removed from view system.
@@ -312,7 +301,6 @@ class SessionManager @JvmOverloads constructor(
         val tabView = tabViewProvider.create()
         session.engineSession?.tabView = tabView
         session.engineSession?.tabView?.setDownloadCallback(downloadCallback)
-        session.engineSession?.tabView?.setFindListener(findListener)
         if (session.engineSession?.webViewState != null) {
             tabView.restoreViewState(session.engineSession?.webViewState)
         } else if (!TextUtils.isEmpty(url)) {
@@ -340,7 +328,6 @@ class SessionManager @JvmOverloads constructor(
 
     private fun destroySession(session: Session) {
         session.engineSession?.tabView?.setDownloadCallback(null)
-        session.engineSession?.tabView?.setFindListener(null)
         unlink(session)
         session.unregisterObservers()
     }

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
@@ -19,7 +19,6 @@ import org.mozilla.rocket.tabs.SessionManager.Factor.FACTOR_TAB_REMOVED
 import org.mozilla.rocket.tabs.SessionManager.Factor.FACTOR_TAB_SWITCHED
 import org.mozilla.rocket.tabs.SessionManager.Observer
 import org.mozilla.rocket.tabs.utils.TabUtil
-import org.mozilla.rocket.tabs.web.DownloadCallback
 import java.lang.ref.WeakReference
 import java.util.ArrayList
 import java.util.LinkedList
@@ -42,8 +41,6 @@ class SessionManager @JvmOverloads constructor(
     private val notifier: Notifier
 
     private var focusRef = WeakReference<Session>(null)
-
-    private var downloadCallback: DownloadCallback? = null
 
     /**
      * To get count of sessions in this session.
@@ -239,21 +236,6 @@ class SessionManager @JvmOverloads constructor(
     }
 
     /**
-     * To specify @see{DownloadCallback} to this session, this method will replace existing one. It
-     * also replace DownloadCallback from any existing Session.
-     *
-     * @param downloadCallback
-     */
-    fun setDownloadCallback(downloadCallback: DownloadCallback?) {
-        this.downloadCallback = downloadCallback
-        if (hasTabs()) {
-            for (session in sessions) {
-                session.engineSession?.tabView?.setDownloadCallback(downloadCallback)
-            }
-        }
-    }
-
-    /**
      * To destroy this session, and it also destroy any sessions in this session.
      * This method should be called after any View has been removed from view system.
      * No other methods may be called on this session after destroy.
@@ -300,7 +282,6 @@ class SessionManager @JvmOverloads constructor(
         val url = if (TextUtils.isEmpty(session.url)) session.initialUrl else session.url
         val tabView = tabViewProvider.create()
         session.engineSession?.tabView = tabView
-        session.engineSession?.tabView?.setDownloadCallback(downloadCallback)
         if (session.engineSession?.webViewState != null) {
             tabView.restoreViewState(session.engineSession?.webViewState)
         } else if (!TextUtils.isEmpty(url)) {
@@ -327,7 +308,6 @@ class SessionManager @JvmOverloads constructor(
     }
 
     private fun destroySession(session: Session) {
-        session.engineSession?.tabView?.setDownloadCallback(null)
         unlink(session)
         session.unregisterObservers()
     }

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
@@ -1,0 +1,108 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.rocket.tabs
+
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Message
+import android.view.View
+import android.webkit.GeolocationPermissions
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
+import android.webkit.WebChromeClient.FileChooserParams
+import mozilla.components.support.base.observer.Consumable
+import org.mozilla.rocket.tabs.TabView.HitTarget
+
+/**
+ * This class is a simulation of EngineSession of Mozilla Android-Components. To be an abstraction
+ * between TabView and Session/SessionManager. Then we can do two things independently.
+ * 1. Refactor Session/SessionManager without worrying TabView.
+ * 2. Refactor TabView/WebkitView without worrying Session.
+ *
+ * This abstraction layer will be removed once we complete migration from TabView to EngineView.
+ */
+class TabViewEngineObserver(
+        val session: Session
+) : TabViewEngineSession.Observer {
+
+    var tabView: TabView? = null
+
+    override fun onTitleChange(title: String) {
+        session.title = title
+        session.notifyObservers { onTitleChanged(session, title) }
+    }
+
+    override fun onLoadingStateChange(loading: Boolean) {
+        session.notifyObservers { onLoadingStateChanged(session, loading) }
+    }
+
+    override fun onSecurityChange(secure: Boolean, host: String?, issuer: String?) =
+            session.notifyObservers { onSecurityChanged(session, secure) }
+
+    override fun onLocationChange(url: String) {
+        session.url = url
+        session.notifyObservers { onUrlChanged(session, url) }
+    }
+
+    override fun updateFailingUrl(url: String?, updateFromError: Boolean) =
+            session.notifyObservers { updateFailingUrl(url, updateFromError) }
+
+    override fun handleExternalUrl(url: String?): Boolean {
+        var consumers = session.wrapConsumers<String?> { url -> handleExternalUrl(url) }
+        return Consumable.from(url).consumeBy(consumers)
+    }
+
+    override fun onCreateWindow(
+            isDialog: Boolean,
+            isUserGesture: Boolean,
+            msg: Message?): Boolean {
+        val consumers = session.wrapConsumers<Triple<Boolean, Boolean, Message?>> {
+            onCreateWindow(it.first, it.second, it.third)
+        }
+        val args = Triple(isDialog, isUserGesture, msg)
+        return Consumable.from(args).consumeBy(consumers)
+    }
+
+    override fun onCloseWindow(es: TabViewEngineSession) {
+        session.notifyObservers { onCloseWindow(es.tabView) }
+    }
+
+    override fun onProgress(progress: Int) {
+        session.notifyObservers { onProgress(session, progress) }
+    }
+
+    override fun onShowFileChooser(es: TabViewEngineSession, filePathCallback: ValueCallback<Array<Uri>>?, fileChooserParams: FileChooserParams?): Boolean {
+        if (tabView == null) {
+            return false
+        }
+
+        val consumers = session.wrapConsumers<Triple<TabView, ValueCallback<Array<Uri>>, WebChromeClient.FileChooserParams>> {
+            onShowFileChooser(it.first, it.second, it.third)
+        }
+        val args = Triple(tabView!!, filePathCallback!!, fileChooserParams!!)
+        return Consumable.from(args).consumeBy(consumers)
+    }
+
+    override fun onReceivedIcon(icon: Bitmap?) {
+        session.favicon = icon
+        session.notifyObservers { onReceivedIcon(icon) }
+    }
+
+    override fun onLongPress(hitTarget: HitTarget) {
+        session.notifyObservers { onLongPress(session, hitTarget) }
+    }
+
+    override fun onEnterFullScreen(callback: TabView.FullscreenCallback, view: View?) =
+            session.notifyObservers { onEnterFullScreen(callback, view) }
+
+    override fun onExitFullScreen() = session.notifyObservers { onExitFullScreen() }
+
+    override fun onGeolocationPermissionsShowPrompt(
+            origin: String,
+            callback: GeolocationPermissions.Callback?) =
+            session.notifyObservers { onGeolocationPermissionsShowPrompt(origin, callback) }
+
+}

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
@@ -6,15 +6,9 @@
 package org.mozilla.rocket.tabs
 
 import android.graphics.Bitmap
-import android.net.Uri
-import android.os.Message
 import android.view.View
 import android.webkit.GeolocationPermissions
-import android.webkit.ValueCallback
-import android.webkit.WebChromeClient
-import android.webkit.WebChromeClient.FileChooserParams
 import mozilla.components.browser.session.Session.SecurityInfo
-import mozilla.components.support.base.observer.Consumable
 import org.mozilla.rocket.tabs.TabView.HitTarget
 
 /**
@@ -28,8 +22,6 @@ import org.mozilla.rocket.tabs.TabView.HitTarget
 class TabViewEngineObserver(
         val session: Session
 ) : TabViewEngineSession.Observer {
-
-    var tabView: TabView? = null
 
     override fun onTitleChange(title: String) {
         session.title = title
@@ -48,43 +40,8 @@ class TabViewEngineObserver(
         session.url = url
     }
 
-    override fun updateFailingUrl(url: String?, updateFromError: Boolean) =
-            session.notifyObservers { updateFailingUrl(url, updateFromError) }
-
-    override fun handleExternalUrl(url: String?): Boolean {
-        var consumers = session.wrapConsumers<String?> { url -> handleExternalUrl(url) }
-        return Consumable.from(url).consumeBy(consumers)
-    }
-
-    override fun onCreateWindow(
-            isDialog: Boolean,
-            isUserGesture: Boolean,
-            msg: Message?): Boolean {
-        val consumers = session.wrapConsumers<Triple<Boolean, Boolean, Message?>> {
-            onCreateWindow(it.first, it.second, it.third)
-        }
-        val args = Triple(isDialog, isUserGesture, msg)
-        return Consumable.from(args).consumeBy(consumers)
-    }
-
-    override fun onCloseWindow(es: TabViewEngineSession) {
-        session.notifyObservers { onCloseWindow(es.tabView) }
-    }
-
     override fun onProgress(progress: Int) {
         session.progress = progress
-    }
-
-    override fun onShowFileChooser(es: TabViewEngineSession, filePathCallback: ValueCallback<Array<Uri>>?, fileChooserParams: FileChooserParams?): Boolean {
-        if (tabView == null) {
-            return false
-        }
-
-        val consumers = session.wrapConsumers<Triple<TabView, ValueCallback<Array<Uri>>, WebChromeClient.FileChooserParams>> {
-            onShowFileChooser(it.first, it.second, it.third)
-        }
-        val args = Triple(tabView!!, filePathCallback!!, fileChooserParams!!)
-        return Consumable.from(args).consumeBy(consumers)
     }
 
     override fun onReceivedIcon(icon: Bitmap?) {

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
@@ -36,6 +36,11 @@ class TabViewEngineObserver(
         // TODO: clear find result, just like AC EngineObserver did.
     }
 
+    override fun onNavigationStateChange(canGoBack: Boolean?, canGoForward: Boolean?) {
+        canGoBack?.let { session.canGoBack = canGoBack }
+        canGoForward?.let { session.canGoForward = canGoForward }
+    }
+
     override fun onSecurityChange(secure: Boolean, host: String?, issuer: String?) {
         session.securityInfo = SecurityInfo(secure, host ?: "", issuer ?: "")
     }

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
@@ -8,6 +8,7 @@ package org.mozilla.rocket.tabs
 import android.graphics.Bitmap
 import android.view.View
 import android.webkit.GeolocationPermissions
+import mozilla.components.browser.session.Session.FindResult
 import mozilla.components.browser.session.Session.SecurityInfo
 import org.mozilla.rocket.tabs.TabView.HitTarget
 
@@ -63,4 +64,7 @@ class TabViewEngineObserver(
             callback: GeolocationPermissions.Callback?) =
             session.notifyObservers { onGeolocationPermissionsShowPrompt(origin, callback) }
 
+    override fun onFindResult(activeMatchOrdinal: Int, numberOfMatches: Int, isDoneCounting: Boolean) {
+        session.findResults += FindResult(activeMatchOrdinal, numberOfMatches, isDoneCounting)
+    }
 }

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
@@ -13,6 +13,7 @@ import android.webkit.GeolocationPermissions
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebChromeClient.FileChooserParams
+import mozilla.components.browser.session.Session.SecurityInfo
 import mozilla.components.support.base.observer.Consumable
 import org.mozilla.rocket.tabs.TabView.HitTarget
 
@@ -32,19 +33,19 @@ class TabViewEngineObserver(
 
     override fun onTitleChange(title: String) {
         session.title = title
-        session.notifyObservers { onTitleChanged(session, title) }
     }
 
     override fun onLoadingStateChange(loading: Boolean) {
-        session.notifyObservers { onLoadingStateChanged(session, loading) }
+        session.loading = loading
+        // TODO: clear find result, just like AC EngineObserver did.
     }
 
-    override fun onSecurityChange(secure: Boolean, host: String?, issuer: String?) =
-            session.notifyObservers { onSecurityChanged(session, secure) }
+    override fun onSecurityChange(secure: Boolean, host: String?, issuer: String?) {
+        session.securityInfo = SecurityInfo(secure, host ?: "", issuer ?: "")
+    }
 
     override fun onLocationChange(url: String) {
         session.url = url
-        session.notifyObservers { onUrlChanged(session, url) }
     }
 
     override fun updateFailingUrl(url: String?, updateFromError: Boolean) =
@@ -71,7 +72,7 @@ class TabViewEngineObserver(
     }
 
     override fun onProgress(progress: Int) {
-        session.notifyObservers { onProgress(session, progress) }
+        session.progress = progress
     }
 
     override fun onShowFileChooser(es: TabViewEngineSession, filePathCallback: ValueCallback<Array<Uri>>?, fileChooserParams: FileChooserParams?): Boolean {

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineObserver.kt
@@ -6,10 +6,13 @@
 package org.mozilla.rocket.tabs
 
 import android.graphics.Bitmap
+import android.os.Environment
 import android.view.View
 import android.webkit.GeolocationPermissions
+import mozilla.components.browser.session.Download
 import mozilla.components.browser.session.Session.FindResult
 import mozilla.components.browser.session.Session.SecurityInfo
+import mozilla.components.support.base.observer.Consumable
 import org.mozilla.rocket.tabs.TabView.HitTarget
 
 /**
@@ -66,5 +69,17 @@ class TabViewEngineObserver(
 
     override fun onFindResult(activeMatchOrdinal: Int, numberOfMatches: Int, isDoneCounting: Boolean) {
         session.findResults += FindResult(activeMatchOrdinal, numberOfMatches, isDoneCounting)
+    }
+
+    override fun onExternalResource(
+            url: String,
+            fileName: String?,
+            contentLength: Long?,
+            contentType: String?,
+            cookie: String?,
+            userAgent: String?) {
+
+        val download = Download(url, fileName, contentType, contentLength, userAgent, Environment.DIRECTORY_DOWNLOADS)
+        session.download = Consumable.from(download)
     }
 }

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineSession.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineSession.kt
@@ -39,8 +39,10 @@ class TabViewEngineSession constructor(
         set(value) {
             value?.setViewClient(ViewClient(this))
             value?.setChromeClient(ChromeClient(this))
+            value?.setFindListener(FindListener(this))
             engineView?.setViewClient(null)
             engineView?.setChromeClient(null)
+            engineView?.setFindListener(null)
             engineView = value
         }
         get() = engineView
@@ -181,5 +183,11 @@ class TabViewEngineSession constructor(
                 origin: String,
                 callback: GeolocationPermissions.Callback?) =
                 es.notifyObservers { onGeolocationPermissionsShowPrompt(origin, callback) }
+    }
+
+    class FindListener(private val es: TabViewEngineSession) : TabView.FindListener {
+        override fun onFindResultReceived(activeMatchOrdinal: Int, numberOfMatches: Int, isDoneCounting: Boolean) {
+            es.notifyObservers { onFindResult(activeMatchOrdinal, numberOfMatches, isDoneCounting) }
+        }
     }
 }

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineSession.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineSession.kt
@@ -121,11 +121,23 @@ class TabViewEngineSession constructor(
         override fun onPageStarted(url: String?) {
             es.notifyObservers { onLoadingStateChange(true) }
             url?.let { es.notifyObservers { onLocationChange(it) } }
+
+            es.tabView?.let {
+                es.notifyObservers {
+                    onNavigationStateChange(it.canGoBack(), it.canGoForward())
+                }
+            }
         }
 
         override fun onPageFinished(isSecure: Boolean) {
             es.notifyObservers { onLoadingStateChange(false) }
             es.notifyObservers { onSecurityChange(isSecure) }
+
+            es.tabView?.let {
+                es.notifyObservers {
+                    onNavigationStateChange(it.canGoBack(), it.canGoForward())
+                }
+            }
         }
 
         override fun onURLChanged(url: String?) {
@@ -169,6 +181,9 @@ class TabViewEngineSession constructor(
         override fun onReceivedTitle(view: TabView, title: String?) {
             if (title != null) {
                 es.notifyObservers { onTitleChange(title) }
+            }
+            es.notifyObservers {
+                onNavigationStateChange(view.canGoBack(), view.canGoForward())
             }
         }
 

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineSession.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/TabViewEngineSession.kt
@@ -1,0 +1,189 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.rocket.tabs
+
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Bundle
+import android.os.Message
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.GeolocationPermissions
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.support.base.observer.Consumable
+import mozilla.components.support.base.observer.Observable
+import mozilla.components.support.base.observer.ObserverRegistry
+
+/**
+ * This class is a simulation of EngineSession of Mozilla Android-Components. To be an abstraction
+ * between TabView and Session/SessionManager. Then we can do two things independently.
+ * 1. Refactor Session/SessionManager without worrying TabView.
+ * 2. Refactor TabView/WebkitView without worrying Session.
+ *
+ * This abstraction layer will be removed once we complete migration from TabView to EngineView.
+ */
+
+class TabViewEngineSession constructor(
+        private val delegate: Observable<TabViewEngineSession.Observer> = ObserverRegistry()
+) : Observable<TabViewEngineSession.Observer> by delegate {
+
+    var webViewState: Bundle? = null
+
+    var tabView: TabView?
+        set(value) {
+            value?.setViewClient(ViewClient(this))
+            value?.setChromeClient(ChromeClient(this))
+            engineView?.setViewClient(null)
+            engineView?.setChromeClient(null)
+            engineView = value
+        }
+        get() = engineView
+
+    private var engineView: TabView? = null
+
+    fun goBack() = tabView?.goBack()
+    fun goForward() = tabView?.goForward()
+    fun loadUrl(url: String) = tabView?.loadUrl(url)
+    fun reload() = tabView?.reload()
+    fun stopLoading() = tabView?.stopLoading()
+
+    /**
+     * To sync session's properties to view, before saving. This method would be retired once we
+     * involve Observable class for those properties.
+     */
+    fun saveState() {
+        if (webViewState == null) {
+            webViewState = Bundle()
+        }
+        tabView?.let {
+            //TODO: should we update latest url, title of TabView to Session?
+            it.saveViewState(webViewState)
+        }
+    }
+
+    /**
+     * To detach @see{android.view.View} of this tab, if any, is detached from its parent.
+     */
+    fun detach() {
+        tabView?.view?.let { v ->
+            v.parent?.let { p ->
+                val parent = p as ViewGroup
+                parent.removeView(v)
+            }
+        }
+    }
+
+    internal fun destroy() {
+        unregisterObservers()
+        // ensure the view not bind to parent
+        detach()
+        tabView?.destroy()
+    }
+
+
+    interface Observer : EngineSession.Observer {
+        fun updateFailingUrl(url: String?, updateFromError: Boolean)
+        fun handleExternalUrl(url: String?): Boolean
+        fun onCreateWindow(isDialog: Boolean,
+                           isUserGesture: Boolean,
+                           msg: Message?): Boolean
+
+        fun onCloseWindow(es: TabViewEngineSession)
+
+        fun onShowFileChooser(
+                es: TabViewEngineSession,
+                filePathCallback: ValueCallback<Array<Uri>>?,
+                fileChooserParams: WebChromeClient.FileChooserParams?): Boolean
+
+        fun onReceivedIcon(icon: Bitmap?)
+        fun onLongPress(hitTarget: TabView.HitTarget)
+        fun onEnterFullScreen(callback: TabView.FullscreenCallback, view: View?)
+        fun onExitFullScreen()
+        fun onGeolocationPermissionsShowPrompt(
+                origin: String,
+                callback: GeolocationPermissions.Callback?)
+    }
+
+    class ViewClient(private val es: TabViewEngineSession) : TabViewClient() {
+        override fun onPageStarted(url: String?) {
+            es.notifyObservers { onLoadingStateChange(true) }
+            url?.let { es.notifyObservers { onLocationChange(it) } }
+        }
+
+        override fun onPageFinished(isSecure: Boolean) {
+            es.notifyObservers { onLoadingStateChange(false) }
+            es.notifyObservers { onSecurityChange(isSecure) }
+        }
+
+        override fun onURLChanged(url: String?) {
+            url?.let { es.notifyObservers { onLocationChange(it) } }
+        }
+
+        override fun updateFailingUrl(url: String?, updateFromError: Boolean) {
+            es.notifyObservers { updateFailingUrl(url, updateFromError) }
+        }
+
+        override fun handleExternalUrl(url: String?): Boolean {
+            var consumers = es.wrapConsumers<String?> { url -> handleExternalUrl(url) }
+            return Consumable.from(url).consumeBy(consumers)
+        }
+    }
+
+    class ChromeClient(private val es: TabViewEngineSession) : TabChromeClient() {
+        override fun onCreateWindow(
+                isDialog: Boolean,
+                isUserGesture: Boolean,
+                msg: Message?): Boolean {
+            val consumers = es.wrapConsumers<Triple<Boolean, Boolean, Message?>> {
+                onCreateWindow(it.first, it.second, it.third)
+            }
+            val args = Triple(isDialog, isUserGesture, msg)
+            return Consumable.from(args).consumeBy(consumers)
+        }
+
+        override fun onCloseWindow(tabView: TabView?) =
+                es.notifyObservers { onCloseWindow(es) }
+
+        override fun onProgressChanged(progress: Int) =
+                es.notifyObservers { onProgress(progress) }
+
+        override fun onShowFileChooser(
+                tabView: TabView,
+                filePathCallback: ValueCallback<Array<Uri>>?,
+                fileChooserParams: WebChromeClient.FileChooserParams?): Boolean {
+
+            val consumers = es.wrapConsumers<Triple<TabViewEngineSession, ValueCallback<Array<Uri>>, WebChromeClient.FileChooserParams>> {
+                this.onShowFileChooser(it.first, it.second, it.third)
+            }
+            val args = Triple(es, filePathCallback!!, fileChooserParams!!)
+            return Consumable.from(args).consumeBy(consumers)
+        }
+
+        override fun onReceivedTitle(view: TabView, title: String?) {
+            if (title != null) {
+                es.notifyObservers { onTitleChange(title) }
+            }
+        }
+
+        override fun onReceivedIcon(view: TabView, icon: Bitmap?) =
+                es.notifyObservers { onReceivedIcon(icon) }
+
+        override fun onLongPress(hitTarget: TabView.HitTarget) =
+                es.notifyObservers { onLongPress(hitTarget) }
+
+        override fun onEnterFullScreen(callback: TabView.FullscreenCallback, view: View?) =
+                es.notifyObservers { onEnterFullScreen(callback, view) }
+
+        override fun onExitFullScreen() = es.notifyObservers { onExitFullScreen() }
+
+        override fun onGeolocationPermissionsShowPrompt(
+                origin: String,
+                callback: GeolocationPermissions.Callback?) =
+                es.notifyObservers { onGeolocationPermissionsShowPrompt(origin, callback) }
+    }
+}

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/web/Download.java
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/web/Download.java
@@ -8,6 +8,7 @@ package org.mozilla.rocket.tabs.web;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 public class Download implements Parcelable {
 
@@ -16,6 +17,7 @@ public class Download implements Parcelable {
         @Override
         public Download createFromParcel(Parcel source) {
             return new Download(
+                    source.readString(),
                     source.readString(),
                     source.readString(),
                     source.readString(),
@@ -31,6 +33,7 @@ public class Download implements Parcelable {
     };
 
     private final String url;
+    private final String name;
     private final String contentDisposition;
     private final String mimeType;
     private final long contentLength;
@@ -38,12 +41,14 @@ public class Download implements Parcelable {
     private final boolean startFromContextMenu;
 
     public Download(@NonNull String url,
+                    @Nullable String name,
                     @NonNull String userAgent,
                     @NonNull String contentDisposition,
                     @NonNull String mimeType,
                     long contentLength,
                     boolean startFromContextMenu) {
         this.url = url;
+        this.name = name;
         this.userAgent = userAgent;
         this.contentDisposition = contentDisposition;
         this.mimeType = mimeType;
@@ -53,6 +58,10 @@ public class Download implements Parcelable {
 
     public String getUrl() {
         return url;
+    }
+
+    public String getName() {
+        return name;
     }
 
     public String getContentDisposition() {
@@ -83,6 +92,7 @@ public class Download implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(url);
+        dest.writeString(name);
         dest.writeString(userAgent);
         dest.writeString(contentDisposition);
         dest.writeString(mimeType);

--- a/components/feature/tabs/src/test/java/org/mozilla/rocket/tabs/SessionManagerTest.kt
+++ b/components/feature/tabs/src/test/java/org/mozilla/rocket/tabs/SessionManagerTest.kt
@@ -45,7 +45,7 @@ class SessionManagerTest {
 
         for (i in urls.indices) {
             // use url as id for convenience
-            val session = Session(urls[i], "", urls[i], urls[i])
+            val session = Session(urls[i], "", urls[i])
             sessions.add(session)
         }
     }

--- a/components/feature/tabs/src/test/java/org/mozilla/rocket/tabs/SessionTest.kt
+++ b/components/feature/tabs/src/test/java/org/mozilla/rocket/tabs/SessionTest.kt
@@ -12,36 +12,33 @@ class SessionTest {
     fun testIsValid() {
         Session(UUID.randomUUID().toString(),
                 "parent_id",
-                "title",
                 "https://mozilla.org").let { model ->
             assertEquals(true, model.isValid())
         }
 
         Session(UUID.randomUUID().toString(),
                 "",
-                "",
                 "https://mozilla.org").let { model ->
             assertEquals(true, model.isValid())
         }
 
         Session(UUID.randomUUID().toString(),
-                null,
                 null,
                 "https://mozilla.org").let { model ->
             assertEquals(true, model.isValid())
         }
 
         // no id, invalid
-        Session("", "", "", "https://mozilla.org").let { model ->
+        Session("", "", "https://mozilla.org").let { model ->
             assertEquals(false, model.isValid())
         }
 
-        Session("", "", "", "").let { model ->
+        Session("", "", "").let { model ->
             assertEquals(false, model.isValid())
         }
 
         // no url, invalid
-        Session(UUID.randomUUID().toString(), "", "", "").let { model ->
+        Session(UUID.randomUUID().toString(), "", "").let { model ->
             assertEquals(false, model.isValid())
         }
 


### PR DESCRIPTION
This PR involves TabViewEngineSession and TabViewEngineObserver.

Rocket has its own WebView abstraction - TabView. Before we involves EngineView from Android-Components, add this abstraction then we can make Session/SessionManager more like what is existing in AC.

This PR also simplify interfaces of Session. Now it becomes only a state-holder, just like the Session of AC.