### PR TITLE
tabs: fix concurrent modification exception

### DIFF
--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
@@ -421,11 +421,8 @@ class SessionManager @JvmOverloads constructor(
 
         override fun onCloseWindow(es: TabViewEngineSession) {
             if (source.engineSession === es) {
-                for (s in sessions) {
-                    if (s.engineSession === es) {
-                        closeTab(s.id)
-                    }
-                }
+                sessions.firstOrNull{ it.engineSession == es}
+                        ?.let { session -> closeTab(session.id) }
             }
         }
     }


### PR DESCRIPTION
the closeTab method itself will modify sessions list, which cause a
concurrent modification exception if we invole `closeTab` inside the
loop.