### PR TITLE
fip: fix crash bug in FindInPage

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/FindInPage.kt
+++ b/app/src/main/java/org/mozilla/focus/widget/FindInPage.kt
@@ -104,7 +104,8 @@ class FindInPage : BackKeyHandleable {
 
     private fun initViews() {
         fun obtainWebView(): WebView? {
-            return (session?.engineSession?.tabView as WebView)
+            val tabView = session?.engineSession?.tabView ?: return null
+            return tabView as WebView
         }
 
         closeBtn.setOnClickListener {
@@ -129,7 +130,7 @@ class FindInPage : BackKeyHandleable {
             }
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                obtainWebView()?.findAllAsync(s.toString())
+                s?.let { obtainWebView()?.findAllAsync(s.toString()) }
             }
         })
 


### PR DESCRIPTION
The TabView might be null, to cast a Null to other type does not make
sense.

to resolve #2851