### PR TITLE
[third-party][glide] Fix build warning of targetSdkVersion with Android Gradle Plugin 3.2.0

### DIFF
--- a/third_party/subsampling-scale-image-view/build.gradle
+++ b/third_party/subsampling-scale-image-view/build.gradle
@@ -4,7 +4,8 @@ android {
     compileSdkVersion Versions.compile_sdk
     buildToolsVersion Versions.build_tools
     defaultConfig {
-        minSdkVersion = 10
+        targetSdkVersion Versions.target_sdk
+        minSdkVersion Versions.min_sdk
     }
 }
 

--- a/third_party/subsampling-scale-image-view/src/main/AndroidManifest.xml
+++ b/third_party/subsampling-scale-image-view/src/main/AndroidManifest.xml
@@ -16,5 +16,4 @@ limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.davemorrissey.labs.subscaleview">
-    <uses-sdk android:targetSdkVersion="14" />
 </manifest>


### PR DESCRIPTION
`targetSdkVersion` should not place in AndroidManifest.xml, put it into `build.gradle` instead.