### PR TITLE
Nevin/determine private mode

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -419,7 +419,7 @@ public class MainActivity extends BaseActivity implements FragmentListener,
 
         final boolean isMyShotUnreadEnabled = AppConfigWrapper.getMyshotUnreadEnabled(this);
         final boolean showUnread = isMyShotUnreadEnabled && Settings.getInstance(this).hasUnreadMyShot();
-        final boolean privateModeActivate = PrivateMode.isPrivateModeProcessRunning(this);
+        final boolean privateModeActivate = PrivateMode.hasPrivateSession(this);
         final Settings settings = Settings.getInstance(getApplicationContext());
 
         myshotIndicator.setVisibility(showUnread ? View.VISIBLE : View.GONE);

--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayFragment.java
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabTrayFragment.java
@@ -200,7 +200,7 @@ public class TabTrayFragment extends DialogFragment implements TabTrayContract.V
     @Override
     public void onResume() {
         super.onResume();
-        tabTrayViewModel.hasPrivateTab().setValue(PrivateMode.isPrivateModeProcessRunning(getContext()));
+        tabTrayViewModel.hasPrivateTab().setValue(PrivateMode.hasPrivateSession(getContext()));
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -246,7 +246,6 @@ object TelemetryWrapper {
             val telemetryEnabled = isTelemetryEnabled(context)
 
             updateDefaultBrowserStatus(context)
-            updatePrefValue(context, resources.getString(R.string.pref_key_webview_version), DebugUtils.loadWebViewVersion(context))
 
             val configuration = TelemetryConfiguration(context)
                     .setServerEndpoint("https://incoming.telemetry.mozilla.org")
@@ -280,10 +279,6 @@ object TelemetryWrapper {
 
     private fun updateDefaultBrowserStatus(context: Context) {
         Settings.updatePrefDefaultBrowserIfNeeded(context, Browsers.isDefaultBrowser(context))
-    }
-
-    private fun updatePrefValue(context: Context, key: String, value: String) {
-        Settings.updatePrefString(context, key, value)
     }
 
     private fun createDefaultSearchProvider(context: Context): DefaultSearchMeasurement.DefaultSearchEngineProvider {

--- a/app/src/main/java/org/mozilla/focus/utils/DebugUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/DebugUtils.java
@@ -17,7 +17,7 @@ public final class DebugUtils {
 
     }
 
-    public static String loadWebViewVersion(Context context) {
+    static String loadWebViewVersion(Context context) {
         String webViewVersion;
         try {
             webViewVersion = loadWebViewVersion(new WebView(context));
@@ -27,10 +27,10 @@ public final class DebugUtils {
         return webViewVersion;
     }
 
-    public static String loadWebViewVersion(WebView webvView) {
+    private static String loadWebViewVersion(WebView webView) {
         String webViewVersion;
         try {
-            final String userAgent = webvView.getSettings().getUserAgentString();
+            final String userAgent = webView.getSettings().getUserAgentString();
             webViewVersion = parseWebViewVersion(userAgent);
         } catch (Throwable error) {
             webViewVersion = UNKNOWN_WEBVIEW_VERSION;
@@ -38,14 +38,13 @@ public final class DebugUtils {
         return webViewVersion;
     }
 
-    private static String parseWebViewVersion(String userAgent) {
+    public static String parseWebViewVersion(String userAgent) {
         if (TextUtils.isEmpty(userAgent)) {
             return UNKNOWN_WEBVIEW_VERSION;
         }
         final String separator = "Chrome/";
         final int from = userAgent.lastIndexOf(separator) + separator.length();
-        final String webviewVersion = userAgent.substring(from, userAgent.indexOf(" ", from));
-        return webviewVersion;
+        return userAgent.substring(from, userAgent.indexOf(" ", from));
     }
 
 }

--- a/app/src/main/java/org/mozilla/focus/widget/CleanBrowsingDataPreference.java
+++ b/app/src/main/java/org/mozilla/focus/widget/CleanBrowsingDataPreference.java
@@ -60,7 +60,7 @@ public class CleanBrowsingDataPreference extends MultiSelectListPreference {
                 } else if (resources.getString(R.string.pref_value_clear_cookies).equals(value)) {
                     CookieManager.getInstance().removeAllCookies(null);
                     // Also clear cookies in private mode process if the process exist
-                    if (PrivateMode.isPrivateModeProcessRunning(getContext())) {
+                    if (PrivateMode.hasPrivateSession(getContext())) {
                         // If there's a private mode process running, below intent will reach
                         // PrivateModeActivity's onNewIntent, thus the activity won't appear again.
                         // (assume that onNewIntent will always runs before onStart()

--- a/app/src/main/java/org/mozilla/rocket/component/RocketLauncherActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/component/RocketLauncherActivity.kt
@@ -4,12 +4,14 @@ import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import org.mozilla.focus.activity.MainActivity
+import org.mozilla.focus.telemetry.TelemetryWrapper
 
 
 class RocketLauncherActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
         val action = LaunchIntentDispatcher.dispatch(this, intent)
         when (action) {
             LaunchIntentDispatcher.Action.HANDLED -> finish()

--- a/app/src/main/java/org/mozilla/rocket/privately/PrivateMode.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/PrivateMode.kt
@@ -55,14 +55,15 @@ class PrivateMode {
         }
 
         /**
-         * A helper function to report whether this service is alive
+         * A helper function to report whether this service is alive.
+         * When there's a private session, it implies a PrivateSessionNotificationService is running.
          *
          * @param context
          * @return true if this service is alive
          */
         @Suppress("deprecation")
         @JvmStatic
-        fun isPrivateModeProcessRunning(context: Context): Boolean {
+        fun hasPrivateSession(context: Context): Boolean {
             val manager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
             // Although this method is no longer available to third party applications.  For backwards compatibility,
             // it will still return the caller's own services.

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -31,6 +31,8 @@
 
     <string name="pref_key_locale" translatable="false"><xliff:g id="preference_key">pref_locale</xliff:g></string>
 
+    <string name="pref_key_webview_version" translatable="false"><xliff:g id="preference_key">pref_webview_version</xliff:g></string>
+
     <string name="pref_key_focus_tab_id" translatable="false"><xliff:g id="preference_key">pref_key_focus_tab_id</xliff:g></string>
 
     <string name="pref_key_category_development" translatable="false"><xliff:g id="preference_key">pref_key_category_development</xliff:g></string>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -31,8 +31,6 @@
 
     <string name="pref_key_locale" translatable="false"><xliff:g id="preference_key">pref_locale</xliff:g></string>
 
-    <string name="pref_key_webview_version" translatable="false"><xliff:g id="preference_key">pref_webview_version</xliff:g></string>
-
     <string name="pref_key_focus_tab_id" translatable="false"><xliff:g id="preference_key">pref_key_focus_tab_id</xliff:g></string>
 
     <string name="pref_key_category_development" translatable="false"><xliff:g id="preference_key">pref_key_category_development</xliff:g></string>

--- a/app/src/webkit/java/org/mozilla/focus/web/WebViewProvider.java
+++ b/app/src/webkit/java/org/mozilla/focus/web/WebViewProvider.java
@@ -18,10 +18,12 @@ import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import org.mozilla.focus.R;
+import org.mozilla.focus.utils.DebugUtils;
 import org.mozilla.focus.utils.Settings;
 import org.mozilla.focus.webkit.DefaultWebView;
 import org.mozilla.focus.webkit.TrackingProtectionWebViewClient;
 import org.mozilla.focus.webkit.WebkitView;
+import org.mozilla.threadutils.ThreadUtils;
 
 /**
  * WebViewProvider for creating a WebKit based IWebVIew implementation.
@@ -205,6 +207,8 @@ public class WebViewProvider {
     public static String getUserAgentString(Context context) {
         if (userAgentString == null) {
             userAgentString = buildUserAgentString(context, context.getResources().getString(R.string.useragent_appname));
+            // we only update the webview version when we first request for user agent string
+            ThreadUtils.postToBackgroundThread(() -> Settings.updatePrefString(context, context.getString(R.string.pref_key_webview_version), DebugUtils.parseWebViewVersion(userAgentString)));
         }
         return userAgentString;
     }


### PR DESCRIPTION
closes #2542

FocusApplication need to know if we are in private mode process, so it
can know when to override getCacheDir to provide the cache folder for
webview/chromium

We use process's name to see if it contains "private_mode" using
acitivityManager.getRunningAppProcesses(). But this method
sometimes return null list so a NullPointerException will be thrown
if we want to use it to check if we are in private mode.

We want to use a new way to determine if we are in prviate mode
process. We want to use the existance of PrivateModeActivity here.

But Telemetry.init() call in FocsApplication will make this hard cause
it make getCacheDir called much more early than PrivateModeActivity is
created. This is because it checked the webview's version in
TelemtryWrapper.init() and call the constructor of WebView.

This makes the chromium code call context.getApplicationContext().getCacheDir() too
early even before the acitvity is created.

Our solution here is to remove the webview version check. But maybe we
can put the version check after the first webView is created and save it
to a shared preference. At the next launch, we just read the pref but we
don't create a webview again just to check the version.

The assumption here is that as long as there's PrivateModateActivity,
this application is in Private Mode process.
This assumption won't hold true if private mode lives in the same
process of normal mode. But this is the design right now.

We should also test if the activity is killed by the system, will this
still work? I assume it will cause there'll never be a
PrivateModeActivity in normal mode.
Need more testing so this can be landed.