### PR TITLE
Restore stored webviewstate properly

### DIFF
--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
@@ -82,6 +82,7 @@ class SessionManager @JvmOverloads constructor(
         for (state in states) {
             if (state.session.isValid()) {
                 getOrCreateEngineSession(state.session).let { link(state.session, it) }
+                state.session.engineSession?.webViewState = state.engineSession?.webViewState
                 this.sessions.add(insertPos++, state.session)
             }
         }


### PR DESCRIPTION
In ab41654, we have changed the way we restore webviewstates. The deserialized states are
stored in a temporary storage SessionWithState. However, the webview state failed to be
passed over to the created engineSession. This commit fixes this missed delegation.

Fixes #2909, Fixes #2951