### PR TITLE
Make Remote Config remote value locale aware. closes #2794

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -142,6 +142,9 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
                 localeManager.setSelectedLocale(getActivity(), value);
             }
             TelemetryWrapper.settingsLocaleChangeEvent(key, String.valueOf(locale), TextUtils.isEmpty(value));
+            FirebaseHelper.updateAppLanguage(getActivity());
+            FirebaseHelper.refreshRemoteConfig();
+
             localeManager.updateConfiguration(getActivity(), locale);
 
             // Manually notify SettingsActivity of locale changes (in most other cases activities

--- a/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.java
+++ b/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.java
@@ -21,11 +21,13 @@ import org.mozilla.focus.R;
 import org.mozilla.focus.activity.MainActivity;
 import org.mozilla.focus.home.FeatureSurveyViewHelper;
 import org.mozilla.focus.home.HomeFragment;
+import org.mozilla.focus.locale.LocaleManager;
 import org.mozilla.focus.notification.RocketMessagingService;
 import org.mozilla.focus.screenshot.ScreenshotManager;
 
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
+import java.util.Locale;
 
 /**
  * Implementation for FirebaseWrapper. It's job:
@@ -35,6 +37,9 @@ import java.util.HashMap;
 final public class FirebaseHelper extends FirebaseWrapper {
 
     private static final String TAG = "FirebaseHelper";
+
+    private static final String USER_PROPERTY_APP_LANGUAGE = "app_lang";
+
 
     // keys for remote config default value
     public static final String RATE_APP_DIALOG_TEXT_TITLE = "rate_app_dialog_text_title";
@@ -191,6 +196,9 @@ final public class FirebaseHelper extends FirebaseWrapper {
 
             enableCrashlytics(applicationContext, enable);
             enableAnalytics(applicationContext, enable);
+
+            updateAppLanguage(applicationContext);
+
             enableCloudMessaging(applicationContext, RocketMessagingService.class.getName(), enable);
             enableRemoteConfig(applicationContext, enable);
 
@@ -217,6 +225,14 @@ final public class FirebaseHelper extends FirebaseWrapper {
             }
         }
 
+    }
+
+    public static void updateAppLanguage(Context context) {
+        Locale current = LocaleManager.getInstance().getCurrentLocale(context);
+        if (current == null) {
+            current = Locale.getDefault();
+        }
+        getInstance().setUserProperty(context, USER_PROPERTY_APP_LANGUAGE, current.toString());
     }
 
     // this is called in FirebaseWrapper's internalInit()

--- a/firebase/src/firebase/java/org/mozilla/focus/utils/FirebaseWrapper.java
+++ b/firebase/src/firebase/java/org/mozilla/focus/utils/FirebaseWrapper.java
@@ -322,7 +322,7 @@ abstract class FirebaseWrapper {
     // Call this method to refresh the value in remote config.
     // Client code can access the remote config value in UI thread. But if the work here is not done,
     // it'll still see the old value.
-    private static void refreshRemoteConfig() {
+    public static void refreshRemoteConfig() {
         final FirebaseRemoteConfig config = remoteConfig.get();
         if (config == null) {
             return;
@@ -376,5 +376,13 @@ abstract class FirebaseWrapper {
             return;
         }
         FirebaseAnalytics.getInstance(context).logEvent(key, param);
+    }
+
+    // Don't want to put refreshRemoteConfig in setUserProperty cause there's limit for fetching the event
+    void setUserProperty(Context context, String key, String value) {
+        if (context == null || key == null) {
+            return;
+        }
+        FirebaseAnalytics.getInstance(context).setUserProperty(key, value);
     }
 }

--- a/firebase/src/firebase_no_op/java/org/mozilla/focus/utils/FirebaseWrapper.java
+++ b/firebase/src/firebase_no_op/java/org/mozilla/focus/utils/FirebaseWrapper.java
@@ -106,4 +106,10 @@ abstract class FirebaseWrapper {
 
     public static void event(Context context, String key, Bundle param) {
     }
+
+    public static void refreshRemoteConfig() {
+    }
+
+    void setUserProperty(Context context, String key, String value) {
+    }
 }


### PR DESCRIPTION
Whenever we change the app language, we change the Firebase user properties "app_lang" to the latest language. And then fetch the remote config from Firebase again ( this will also call `activateFetched()` so it'll take effect immediately )

I separate this PR with #2981 , because I think this PR may not be helpful since
1. User properties update takes time. So the test case will fail. [see below in the official document](https://firebase.google.com/docs/analytics/android/properties?hl=zh-TW#add_analytics_to_your_app) 
>Note: Once the property is registered, it can take several hours for data collected with the property to be included in reports. When the new data is available, the user property can be used as a report filter or audience definition.

2. The more value part for this PR, is that after this PR, we need to use "user property-app_lang" instead of "locale" in Firebase. Cause the real app language the users are using is "user property-app_lang" .
Something need more testing: If "user property-app_lang"  is required when user first launch the app, this user property may not be there if it'll take hours to update to Firebase. That means we can't use app_lang as an condition for first used users.

