### PR TITLE
Make Remote Config default value locale aware closes #2828

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -143,6 +143,7 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
             }
             TelemetryWrapper.settingsLocaleChangeEvent(key, String.valueOf(locale), TextUtils.isEmpty(value));
             localeManager.updateConfiguration(getActivity(), locale);
+            FirebaseHelper.onLocaleUpdate(getActivity());
 
             // Manually notify SettingsActivity of locale changes (in most other cases activities
             // will detect changes in onActivityResult(), but that doesn't apply to SettingsActivity).

--- a/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.java
+++ b/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.java
@@ -13,6 +13,7 @@ import android.os.StrictMode;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.support.annotation.WorkerThread;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
@@ -236,6 +237,13 @@ final public class FirebaseHelper extends FirebaseWrapper {
         return remoteConfigDefault;
     }
 
+    @Override
+    void refreshRemoteConfigDefault(Context context) {
+        remoteConfigDefault = null;
+        getRemoteConfigDefault(context);
+    }
+
+
     private HashMap<String, Object> fromFile(Context context) {
 
         // If we don't have read external storage permission, just don't bother reading the config file.
@@ -287,4 +295,7 @@ final public class FirebaseHelper extends FirebaseWrapper {
         }
     }
 
+    public static void onLocaleUpdate(Context context) {
+        getInstance().refreshRemoteConfigDefault(context);
+    }
 }

--- a/firebase/src/firebase/java/org/mozilla/focus/utils/FirebaseWrapper.java
+++ b/firebase/src/firebase/java/org/mozilla/focus/utils/FirebaseWrapper.java
@@ -347,6 +347,9 @@ abstract class FirebaseWrapper {
     // Client code must implement this method so it's not static here.
     abstract HashMap<String, Object> getRemoteConfigDefault(Context context);
 
+    // Client code must implement this method so it's not static here.
+    abstract void refreshRemoteConfigDefault(Context context);
+
     @Nullable
     public static String getFcmToken() {
         try {

--- a/firebase/src/firebase_no_op/java/org/mozilla/focus/utils/FirebaseWrapper.java
+++ b/firebase/src/firebase_no_op/java/org/mozilla/focus/utils/FirebaseWrapper.java
@@ -100,6 +100,8 @@ abstract class FirebaseWrapper {
     // Client code must implement this method so it's not static here.
     abstract HashMap<String, Object> getRemoteConfigDefault(Context context);
 
+    abstract void refreshRemoteConfigDefault(Context context);
+
     public static String getFcmToken() {
         return FIREBASE_STRING_DEFAULT;
     }


### PR DESCRIPTION
Whenever we change the app language, we clear the default value and request from the translated string resource again.