### PR TITLE
Remove browsingWebsiteBackAndForward_backAndFrowardToWebsite test for intermittent. see: #2932

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/NavigationTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/NavigationTest.java
@@ -32,8 +32,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
-@Keep
-@RunWith(AndroidJUnit4.class)
 public class NavigationTest {
 
     @Rule
@@ -48,7 +46,6 @@ public class NavigationTest {
         activityTestRule.launchActivity(new Intent());
     }
 
-    @Test
     public void browsingWebsiteBackAndForward_backAndFrowardToWebsite() {
 
         final SessionLoadedIdlingResource loadingIdlingResource = new SessionLoadedIdlingResource(activityTestRule.getActivity());


### PR DESCRIPTION
Please leave the bug open so it can be fixed in the future.
The way we check page loading complete should change from BrowserFragment's isLoading flag to SessionObserver 