### PR TITLE
Live data should only be responsible for the first new tab. closes #2432

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragment.kt
@@ -83,11 +83,6 @@ class BrowserFragment : LocaleAwareFragment(),
             if (BuildConfig.DEBUG) {
                 throw RuntimeException("No activity to use")
             }
-        } else {
-            if (fragmentActivity is TabsSessionProvider.SessionHost) {
-                sessionManager = fragmentActivity.sessionManager
-                observer = Observer(this)
-            }
         }
     }
 
@@ -121,23 +116,29 @@ class BrowserFragment : LocaleAwareFragment(),
             (v.layoutParams as LinearLayout.LayoutParams).topMargin = insets.systemWindowInsetTop
             insets
         }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        sessionManager.resume()
+        sessionManager = TabsSessionProvider.getOrThrow( activity)
+        observer = Observer(this)
         sessionManager.register(observer)
         sessionManager.focusSession?.register(observer)
 
         activity?.let { registerData(it) }
     }
 
-    override fun onPause() {
-        super.onPause()
+    override fun onDestroyView() {
+        super.onDestroyView()
         activity?.let { unregisterData(it) }
 
         sessionManager.focusSession?.unregister(observer)
         sessionManager.unregister(observer)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        sessionManager.resume()
+    }
+
+    override fun onPause() {
+        super.onPause()
         sessionManager.pause()
     }
 


### PR DESCRIPTION
Currently, loadUrl in PB mode is controlled by LiveData. register in onResume will trigger the url loading again. There are two approaches to fix this 
1. Update the LiveData when onPause
2. Move LiveData registration to onViewCreated. So only when Private BrowserFragment.kt is added (the user starts a new private session) will trigger loadUrl ( add a new tab, for example)

I choose approach 2. There's no reason to trigger a reload for just onResume/onPause.