### PR TITLE
Reduce CPU usage of ui-progress when idling. closes #2454

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/AnimatedProgressBar.java
+++ b/app/src/main/java/org/mozilla/focus/widget/AnimatedProgressBar.java
@@ -233,13 +233,6 @@ public class AnimatedProgressBar extends ProgressBar {
         mIsRtl = (ViewCompat.getLayoutDirection(this) == ViewCompat.LAYOUT_DIRECTION_RTL);
     }
 
-    @Override
-    public Parcelable onSaveInstanceState() {
-        // Force update as 0 (Don't save state) for ProgressBar to avoid 0 -> 100 end animation
-        setProgress(0);
-        return super.onSaveInstanceState();
-    }
-
     private void cancelAnimations() {
         if (mPrimaryAnimator != null) {
             mPrimaryAnimator.cancel();
@@ -261,6 +254,9 @@ public class AnimatedProgressBar extends ProgressBar {
         a.recycle();
 
         setProgressDrawable(buildDrawable(getProgressDrawable(), wrap, duration, itplId));
+        if (getProgress() == 0) {
+            setVisibilityImmediately(GONE);
+        }
 
         mPrimaryAnimator = createAnimator(getMax(), mListener);
 
@@ -297,6 +293,11 @@ public class AnimatedProgressBar extends ProgressBar {
 
     private void setVisibilityImmediately(int value) {
         super.setVisibility(value);
+        if (value == GONE) {
+            getProgressDrawable().setVisible(false, false);
+        } else {
+            getProgressDrawable().setVisible(true, true);
+        }
     }
 
     private void animateClosing() {

--- a/app/src/main/java/org/mozilla/focus/widget/ShiftDrawable.java
+++ b/app/src/main/java/org/mozilla/focus/widget/ShiftDrawable.java
@@ -58,10 +58,10 @@ public class ShiftDrawable extends DrawableWrapper {
     @Override
     public boolean setVisible(boolean visible, boolean restart) {
         final boolean result = super.setVisible(visible, restart);
-        if (isVisible()) {
+        if (visible && restart) {
             mAnimator.start();
         } else {
-            mAnimator.end();
+            mAnimator.cancel();
         }
         return result;
     }


### PR DESCRIPTION
Calling DrawableWrapper.isVisible() will return true by default unless we explicitly set it to false. So when
1. Opening the app
2. Returning the app from recent apps
So the animation will start even though the progress bar is hidden.

Here I only start the animation when setting the progress and explicitly passing `visible=true, restart=true` to `DrawableWrapper.setVisible(visible, restart)`

I also remove the `onSaveInstanceState` code since
1.  It's not required under our current session. Observer architecture.
2. setProgress(0) in the old code will trigger visibility change again and start the animation unexpectedly. Which we don't expect this behaviour (setting progress by non-sessionObserver)