### PR TITLE
Switch search code to new Google code. closes #2997

### DIFF
--- a/app/src/androidTest/assets/search/default/google-b-m-mock.xml
+++ b/app/src/androidTest/assets/search/default/google-b-m-mock.xml
@@ -10,13 +10,12 @@
   <Param name="q" value="{searchTerms}"/>
   <Param name="ie" value="utf-8"/>
   <Param name="oe" value="utf-8"/>
-  <Param name="hl" value="{language}"/>
 </Url>
-<Url type="text/html" method="GET" template="https://www.google.com/search">
+<Url type="text/html" method="GET" template="https://www-mock.google.com/search">
   <Param name="q" value="{searchTerms}"/>
   <Param name="ie" value="utf-8"/>
   <Param name="oe" value="utf-8"/>
-  <Param name="client" value="firefox-b"/>
+  <Param name="client" value="firefox-b-m"/>
 </Url>
 <SearchForm>https://www.google.com</SearchForm>
 </SearchPlugin>

--- a/app/src/androidTest/assets/search/search_configuration.json
+++ b/app/src/androidTest/assets/search/search_configuration.json
@@ -1,1 +1,1 @@
-{"default": ["google-mock", "yahoo-id-mock", "duckduckgo-mock", "wikipedia-id-mock"]}
+{"default": ["google-b-m-mock", "yahoo-id-mock", "duckduckgo-mock", "wikipedia-id-mock"]}

--- a/app/src/main/assets/search/default/google-b-m.xml
+++ b/app/src/main/assets/search/default/google-b-m.xml
@@ -10,12 +10,13 @@
   <Param name="q" value="{searchTerms}"/>
   <Param name="ie" value="utf-8"/>
   <Param name="oe" value="utf-8"/>
+  <Param name="hl" value="{language}"/>
 </Url>
-<Url type="text/html" method="GET" template="https://www-mock.google.com/search">
+<Url type="text/html" method="GET" template="https://www.google.com/search">
   <Param name="q" value="{searchTerms}"/>
   <Param name="ie" value="utf-8"/>
   <Param name="oe" value="utf-8"/>
-  <Param name="client" value="firefox-b"/>
+  <Param name="client" value="firefox-b-m"/>
 </Url>
 <SearchForm>https://www.google.com</SearchForm>
 </SearchPlugin>

--- a/app/src/main/assets/search/search_configuration.json
+++ b/app/src/main/assets/search/search_configuration.json
@@ -1,1 +1,1 @@
-{ "default": ["google", "yahoo", "duckduckgo"], "id": ["google", "yahoo-id", "duckduckgo"]}
+{ "default": ["google-b-m", "yahoo", "duckduckgo"], "id": ["google", "yahoo-id", "duckduckgo"]}


### PR DESCRIPTION
After consulting Mike Kaply.
This bug is easy to test:
1. Open Firefox Lite
2. Search in Google
3. see the client info in the result url. Now it should be firexfox-b-m
![image](https://user-images.githubusercontent.com/1287363/50229497-69dd0f80-03e5-11e9-9b93-4e369fe1da17.png)
