### PR TITLE
Add null check for Adjust and TelemetryWarpper

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -224,9 +224,14 @@ object TelemetryWrapper {
         DISMISS
     }
 
+    // context passed here is nullable cause it may come from Java code
     @JvmStatic
-    fun isTelemetryEnabled(context: Context): Boolean {
-        return Inject.isTelemetryEnabled(context)
+    fun isTelemetryEnabled(context: Context?): Boolean {
+        return if (context == null) {
+            false
+        } else {
+            Inject.isTelemetryEnabled(context)
+        }
     }
 
     @JvmStatic

--- a/app/src/release/java/org/mozilla/focus/utils/AdjustHelper.java
+++ b/app/src/release/java/org/mozilla/focus/utils/AdjustHelper.java
@@ -19,8 +19,11 @@ import org.mozilla.focus.BuildConfig;
 import org.mozilla.focus.FocusApplication;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
 
+import javax.annotation.Nullable;
+
 public class AdjustHelper {
 
+    @Nullable
     private static FocusApplication focusApplication;
 
     public static void setupAdjustIfNeeded(FocusApplication application) {
@@ -53,7 +56,7 @@ public class AdjustHelper {
     }
 
     public static void trackEvent(String eventToken) {
-        if (TelemetryWrapper.isTelemetryEnabled(focusApplication)) {
+        if (focusApplication != null && TelemetryWrapper.isTelemetryEnabled(focusApplication)) {
             Adjust.trackEvent(new AdjustEvent(eventToken));
         }
     }


### PR DESCRIPTION
applicationContext in Adjust.java may be null. And the caller for TelemetryWarpper.isTelemetryEnabled could pass null. closes #3001