### PR TITLE
Re-enable Firebase RemoteConfig after in-app locale change closes #2794

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.java
+++ b/app/src/main/java/org/mozilla/focus/utils/FirebaseHelper.java
@@ -24,6 +24,7 @@ import org.mozilla.focus.home.FeatureSurveyViewHelper;
 import org.mozilla.focus.home.HomeFragment;
 import org.mozilla.focus.notification.RocketMessagingService;
 import org.mozilla.focus.screenshot.ScreenshotManager;
+import org.mozilla.focus.telemetry.TelemetryWrapper;
 
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
@@ -239,8 +240,11 @@ final public class FirebaseHelper extends FirebaseWrapper {
 
     @Override
     void refreshRemoteConfigDefault(Context context) {
+        // Clear remoteConfigDefault
         remoteConfigDefault = null;
         getRemoteConfigDefault(context);
+        // Now also need to reset the default config in Firebase if "Send Usage Data" is turned on.
+        enableRemoteConfig(context, TelemetryWrapper.isTelemetryEnabled(context));
     }
 
 


### PR DESCRIPTION
When users change the in-app locale, if "Send Usage Data" is turned on, the default value for Firebase Remote Config isn't changed.
We not only need to update the default value in local device, also need to update the default value in Firebase RemoteConfig SDK.

